### PR TITLE
Add support for patching case classes with JSON

### DIFF
--- a/generic/src/main/scala/io/circe/generic/IncompleteInstances.scala
+++ b/generic/src/main/scala/io/circe/generic/IncompleteInstances.scala
@@ -10,4 +10,10 @@ trait IncompleteInstances {
     complement: Complement.Aux[T, P, R],
     d: Decoder[R]
   ): Decoder[F] = d.map(r => ffp(p => gen.from(complement.insert(p, r))))
+
+  implicit def decodeCaseClassPatch[A, R <: HList, O <: HList](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    patch: PatchWithOptions.Aux[R, O],
+    d: Decoder[O]
+  ): Decoder[A => A] = d.map(o => a => gen.from(patch(gen.to(a), o)))
 }

--- a/generic/src/main/scala/io/circe/generic/PatchWithOptions.scala
+++ b/generic/src/main/scala/io/circe/generic/PatchWithOptions.scala
@@ -1,0 +1,34 @@
+package io.circe.generic
+
+import shapeless._
+import shapeless.labelled.{ FieldType, field }
+
+trait PatchWithOptions[R <: HList] {
+  type Out <: HList
+
+  def apply(r: R, o: Out): R
+}
+
+object PatchWithOptions {
+  type Aux[R <: HList, Out0 <: HList] = PatchWithOptions[R] { type Out = Out0 }
+
+  implicit val hnilPatchWithOptions: Aux[HNil, HNil] =
+    new PatchWithOptions[HNil] {
+      type Out = HNil
+
+      def apply(r: HNil, o: HNil): HNil = HNil
+    }
+
+  implicit def hconsPatchWithOptions[K <: Symbol, V, T <: HList](implicit
+    tailPatch: PatchWithOptions[T]
+  ): Aux[FieldType[K, V] :: T, FieldType[K, Option[V]] :: tailPatch.Out] =
+    new PatchWithOptions[FieldType[K, V] :: T] {
+      type Out = FieldType[K, Option[V]] :: tailPatch.Out
+
+      def apply(
+        r: FieldType[K, V] :: T,
+        o: FieldType[K, Option[V]] :: tailPatch.Out
+      ): FieldType[K, V] :: T =
+        field[K](o.head.getOrElse(r.head)) :: tailPatch(r.tail, o.tail)
+    }
+}

--- a/generic/src/test/scala/io/circe/generic/SemiautoCodecTests.scala
+++ b/generic/src/test/scala/io/circe/generic/SemiautoCodecTests.scala
@@ -32,6 +32,21 @@ class SemiautoCodecTests extends CirceSuite with Examples {
     }
   }
 
+  test("Decoder[Qux[String] => Qux[String]]") {
+    check {
+      forAll { (q: Qux[String], i: Option[Int], a: Option[String]) =>
+        val json = Json.obj(
+          "i" -> Encoder[Option[Int]].apply(i),
+          "a" -> Encoder[Option[String]].apply(a)
+        )
+
+        val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a))
+
+        json.as[Qux[String] => Qux[String]].map(_(q)) === Xor.right(expected)
+      }
+    }
+  }
+
   test("Tuples should be encoded as JSON arrays") {
     check {
       forAll { (t: (Int, String, Char)) =>

--- a/generic/src/test/scala/io/circe/generic/auto/AutoCodecTests.scala
+++ b/generic/src/test/scala/io/circe/generic/auto/AutoCodecTests.scala
@@ -27,6 +27,21 @@ class AutoCodecTests extends CirceSuite with Examples {
     }
   }
 
+  test("Decoder[Qux[String] => Qux[String]]") {
+    check {
+      forAll { (q: Qux[String], i: Option[Int], a: Option[String]) =>
+        val json = Json.obj(
+          "i" -> Encoder[Option[Int]].apply(i),
+          "a" -> Encoder[Option[String]].apply(a)
+        )
+
+        val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a))
+
+        json.as[Qux[String] => Qux[String]].map(_(q)) === Xor.right(expected)
+      }
+    }
+  }
+
   test("Tuples should be encoded as JSON arrays") {
     check {
       forAll { (t: (Int, String, Char)) =>


### PR DESCRIPTION
As [requested](https://gitter.im/travisbrown/circe?at=55c8e6750c29567545d98e4a) by @vkostyukov, this addition supports the derivation of case class "updaters":

```scala
scala> import io.circe.generic.auto._, io.circe.jawn._
import io.circe.generic.auto._
import io.circe.jawn._

scala> case class Foo(i: Int, xs: List[String])
defined class Foo

scala> val foo = Foo(0, Nil)
foo: Foo = Foo(0,List())

scala> decode[Foo => Foo]("""{ "i": 13 }""").map(_(foo))
res0: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(13,List()))

scala> decode[Foo => Foo]("""{ "xs": ["a", "b"] }""").map(_(foo))
res1: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(0,List(a, b)))

scala> decode[Foo => Foo]("""{ "xs": ["a", "b"], "i": 1 }""").map(_(foo))
res2: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(1,List(a, b)))
```

This is closely related to ["incomplete" decoder derivation](https://meta.plasm.us/posts/2015/06/21/deriving-incomplete-type-class-instances/) and the motivation is similar: we want to avoid lots of case classes like `PatchedTodo` here:

```scala
case class Todo(id: String, title: String, completed: Boolean, order: Int)
case class PatchedTodo(title: Option[String], completed: Option[Boolean], order: Option[Int])
```

`Decoder[Foo => Foo]` lets us accomplish the same thing without an extra boilerplate-y case class.

