### PR TITLE
Add tests and fix a few small bugs in cursors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ lazy val core = project
   .settings(
     libraryDependencies ++= Seq(
       "org.spire-math" %% "cats-core" % "0.1.2",
-      "org.spire-math" %% "cats-std" % "0.1.2"
+      "org.spire-math" %% "cats-std" % "0.1.2",
+      "io.argonaut" %% "argonaut" % "6.1" % "test"
     )
   )
 

--- a/core/src/main/scala/io/circe/GenericCursor.scala
+++ b/core/src/main/scala/io/circe/GenericCursor.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import cats.Functor
 import cats.data.Xor
 
 /**
@@ -64,7 +65,7 @@ trait GenericCursor[C <: GenericCursor[C]] {
    *
    * @group TypeMembers
    */
-  type M[_[_]]
+  type M[F[_]] <: Functor[F]
 
   /**
    * The current location in the document.

--- a/core/src/main/scala/io/circe/cursor/CArray.scala
+++ b/core/src/main/scala/io/circe/cursor/CArray.scala
@@ -13,7 +13,7 @@ private[circe] case class CArray(
   def context: List[Context] = Context.inArray(focus, ls.length) :: p.context
 
   def up: Option[Cursor] = Some {
-    val j = Json.fromValues(ls.reverse_:::(focus :: rs))
+    val j = Json.fromValues((focus :: rs).reverse_:::(ls))
 
     p match {
       case CJson(_) => CJson(j)
@@ -23,7 +23,7 @@ private[circe] case class CArray(
   }
 
   def delete: Option[Cursor] = Some {
-    val j = Json.fromValues(ls.reverse_:::(rs))
+    val j = Json.fromValues(rs.reverse_:::(ls))
 
     p match {
       case CJson(_) => CJson(j)
@@ -49,12 +49,12 @@ private[circe] case class CArray(
     case Nil => None
   }
 
-  override def first: Option[Cursor] = ls.reverse_:::(focus :: rs) match {
+  override def first: Option[Cursor] = (focus :: rs).reverse_:::(ls) match {
     case h :: t => Some(CArray(h, p, u, Nil, t))
     case Nil => None
   }
 
-  override def last: Option[Cursor] = rs.reverse_:::(focus :: ls) match {
+  override def last: Option[Cursor] = (focus :: ls).reverse_:::(rs) match {
     case h :: t => Some(CArray(h, p, u, t, Nil))
     case Nil => None
   }
@@ -69,12 +69,12 @@ private[circe] case class CArray(
     case Nil => None
   }
 
-  override def deleteGoFirst: Option[Cursor] = ls.reverse_:::(rs) match {
+  override def deleteGoFirst: Option[Cursor] = rs.reverse_:::(ls) match {
     case h :: t => Some(CArray(h, p, true, Nil, t))
     case Nil => None
   }
 
-  override def deleteGoLast: Option[Cursor] = rs.reverse_:::(ls) match {
+  override def deleteGoLast: Option[Cursor] = ls.reverse_:::(rs) match {
     case h :: t => Some(CArray(h, p, true, t, Nil))
     case Nil => None
   }

--- a/core/src/main/scala/io/circe/cursor/CObject.scala
+++ b/core/src/main/scala/io/circe/cursor/CObject.scala
@@ -41,6 +41,6 @@ private[circe] case class CObject(
   }
 
   override def deleteGoField(k: String): Option[Cursor] = o(k).map { j =>
-    copy(focus = j, key = k, o = o - k)
+    copy(focus = j, key = k, u = true, o = o - key)
   }
 }

--- a/core/src/main/scala/io/circe/cursor/CursorOperations.scala
+++ b/core/src/main/scala/io/circe/cursor/CursorOperations.scala
@@ -18,7 +18,7 @@ private[circe] trait CursorOperations extends GenericCursor[Cursor] { this: Curs
     def go(c: Cursor): Json = c match {
       case CJson(j) => j
       case CArray(j, p, u, ls, rs) =>
-        val q = Json.fromValues(ls.reverse_:::(j :: rs))
+        val q = Json.fromValues((j :: rs).reverse_:::(ls))
 
         go(
           p match {

--- a/core/src/test/scala/io/circe/CodecTests.scala
+++ b/core/src/test/scala/io/circe/CodecTests.scala
@@ -41,3 +41,37 @@ class DisjunctionCodecTests extends CirceSuite {
   checkAll("Codec[Either[Int, String]]", CodecTests[Either[Int, String]].codec)
   checkAll("Codec[Validated[String, Int]]", CodecTests[Validated[String, Int]].codec)
 }
+
+class DecodingFailureTests extends CirceSuite {
+  val n = Json.int(10)
+  val b = Json.True
+  val s = Json.string("foo")
+  val l = Json.array(s)
+  val o = Json.obj("foo" -> n)
+
+  val nd = Decoder[Int]
+  val bd = Decoder[Boolean]
+  val sd = Decoder[String]
+  val ld = Decoder[List[String]]
+  val od = Decoder[Map[String, Int]]
+
+  test("Decoding a JSON number as anything else should fail") {
+    assert(List(bd, sd, ld, od).forall(d => d.decodeJson(n).isLeft))
+  }
+
+  test("Decoding a JSON boolean as anything else should fail") {
+    assert(List(nd, sd, ld, od).forall(d => d.decodeJson(b).isLeft))
+  }
+
+  test("Decoding a JSON string as anything else should fail") {
+    assert(List(nd, bd, ld, od).forall(d => d.decodeJson(s).isLeft))
+  }
+
+  test("Decoding a JSON array as anything else should fail") {
+    assert(List(nd, bd, sd, od).forall(d => d.decodeJson(l).isLeft))
+  }
+
+  test("Decoding a JSON object as anything else should fail") {
+    assert(List(nd, bd, sd, ld).forall(d => d.decodeJson(o).isLeft))
+  }
+}

--- a/core/src/test/scala/io/circe/CursorTests.scala
+++ b/core/src/test/scala/io/circe/CursorTests.scala
@@ -1,6 +1,8 @@
 package io.circe
 
+import cats.{ Applicative, Functor }
 import cats.data.{ NonEmptyList, Validated, Xor }
+import cats.std.list._
 import io.circe.test.CursorSuite
 
 class CursorTests extends CursorSuite[Cursor] {

--- a/core/src/test/scala/io/circe/JsonObjectTests.scala
+++ b/core/src/test/scala/io/circe/JsonObjectTests.scala
@@ -1,0 +1,69 @@
+package io.circe
+
+import cats.laws.discipline.eq._
+import io.circe.test.CirceSuite
+import org.scalacheck.{ Arbitrary, Gen }
+
+class JsonObjectTests extends CirceSuite {
+  test("+: with duplicate") {
+    check { (j: Json, h: Json, t: List[Json]) =>
+      val fields = (h :: t).zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }
+
+      (("0" -> j) +: JsonObject.from(fields)).toList === (("0" -> j) :: fields.tail)
+    }
+  }
+
+  test("size") {
+    check { (js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }
+
+      JsonObject.from(fields).size === fields.size
+    }
+  }
+
+  test("withJsons") {
+    check { (j: Json, js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }
+
+      JsonObject.from(fields).withJsons(_ => j).values === List.fill(js.size)(j)
+    }
+  }
+
+  test("toList") {
+    check { (js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }.reverse
+
+      JsonObject.from(fields).toList === fields
+    }
+  }
+
+  test("values") {
+    check { (js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }.reverse
+
+      JsonObject.from(fields).values === fields.map(_._2)
+    }
+  }
+
+  test("traverse") {
+    check { (js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }
+
+      val o = JsonObject.from(fields)
+
+      o.traverse[Option](j => Some(j)) === Some(o)
+    }
+  }
+}

--- a/core/src/test/scala/io/circe/PrinterTests.scala
+++ b/core/src/test/scala/io/circe/PrinterTests.scala
@@ -1,0 +1,20 @@
+package io.circe
+
+import argonaut._, Argonaut._
+import io.circe.test.{ PrinterTests, CirceSuite }
+
+class PrinterSuite(printer: Printer) extends CirceSuite {
+  checkAll("Printing Unit", PrinterTests[Unit].printer(printer))
+  checkAll("Printing Boolean", PrinterTests[Boolean].printer(printer))
+  checkAll("Printing Char", PrinterTests[Char].printer(printer))
+  checkAll("Printing Float", PrinterTests[Float].printer(printer))
+  checkAll("Printing Double", PrinterTests[Double].printer(printer))
+  checkAll("Printing Short", PrinterTests[Short].printer(printer))
+  checkAll("Printing Int", PrinterTests[Int].printer(printer))
+  checkAll("Printing Long", PrinterTests[Long].printer(printer))
+  checkAll("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer))
+}
+
+class NoSpacesPrinterTests extends PrinterSuite(Printer.noSpaces)
+class Spaces2PrinterTests extends PrinterSuite(Printer.noSpaces)
+class Spaces4PrinterTests extends PrinterSuite(Printer.spaces4)

--- a/core/src/test/scala/io/circe/test/CodecTests.scala
+++ b/core/src/test/scala/io/circe/test/CodecTests.scala
@@ -9,9 +9,6 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.typelevel.discipline.Laws
 
-/**
- * 
- */
 trait CodecLaws[A] {
   def decode: Decoder[A]
   def encode: Encoder[A]

--- a/core/src/test/scala/io/circe/test/CursorSuite.scala
+++ b/core/src/test/scala/io/circe/test/CursorSuite.scala
@@ -5,8 +5,11 @@ import cats.data.{ NonEmptyList, Validated, Xor }
 import io.circe.{ Cursor, GenericCursor, Json }
 import io.circe.syntax._
 
-abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends CirceSuite {
-  def fromJson(j: Json): C
+abstract class CursorSuite[C <: GenericCursor[C]](implicit
+  eq: Eq[C],
+  M: C#M[List]
+) extends CirceSuite {
+  def fromJson(j: Json): C { type M[x[_]] = C#M[x] }
   def top(c: C): Option[Json]
   def focus(c: C): Option[Json]
   def fromResult(result: C#Result): Option[C]
@@ -36,11 +39,46 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Ci
 
   val cursor: C = fromJson(j1)
 
+  test("focus") {
+    check { (j: Json) =>
+      focus(fromJson(j)) === Some(j)
+    }
+  }
+
+  test("withFocus(identity)") {
+    check { (j: Json) =>
+      focus(fromJson(j).withFocus(identity)) === Some(j)
+    }
+  }
+
+  test("withFocusM(List(_))") {
+    check { (j: Json) =>
+      focus(fromJson(j).withFocusM[List](List(_))(M).head) === Some(j)
+    }
+  }
+
+  test("delete") {
+    val result = fromResult(cursor.downField("b")).flatMap(c => fromResult(c.delete))
+
+    assert(result.flatMap(top) === Some(j4))
+  }
+
+  test("delete in array") {
+    check { (h: Json, t: List[Json]) =>
+      val result = for {
+        f <- fromResult(fromJson(Json.fromValues(h :: t)).downArray)
+        u <- fromResult(f.delete)
+      } yield u
+
+      result.flatMap(focus) === Some(Json.fromValues(t))
+    }
+  }
+
   test("withFocus") {
     val result = fromResult(cursor.downField("a")).map(
-    	_.withFocus(j =>
-    		j.asArray.fold(j)(a => Json.fromValues(0.asJson :: a))
-    	)
+      _.withFocus(j =>
+        j.asArray.fold(j)(a => Json.fromValues(0.asJson :: a))
+      )
     )
     
     assert(result.flatMap(top) === Some(j2))
@@ -118,9 +156,195 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit eq: Eq[C]) extends Ci
     assert(result.flatMap(focus) === None)
   }
 
-  test("delete") {
-    val result = fromResult(cursor.downField("b")).flatMap(c => fromResult(c.delete))
+  test("valid first") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.first)
+    } yield l
 
-    assert(result.flatMap(top) === Some(j4))
+    assert(result.flatMap(focus) === Some(1.asJson))
+  }
+
+  test("invalid first") {
+    val result = for {
+      c <- fromResult(cursor.downField("b"))
+      l <- fromResult(c.first)
+    } yield l
+
+    assert(result.flatMap(focus) === None)
+  }
+
+  test("valid last") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.last)
+    } yield l
+
+    assert(result.flatMap(focus) === Some(5.asJson))
+  }
+
+  test("invalid last") {
+    val result = for {
+      c <- fromResult(cursor.downField("b"))
+      l <- fromResult(c.last)
+    } yield l
+
+    assert(result.flatMap(focus) === None)
+  }
+
+  test("field") {
+    val result = for {
+      c <- fromResult(cursor.downField("c"))
+      e <- fromResult(c.downField("e"))
+      f <- fromResult(e.field("f"))
+    } yield f
+
+    assert(result.flatMap(focus) === Some(200.2.asJson))
+  }
+
+  test("deleteGoLeft") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.deleteGoLeft)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(3.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 3, 5).asJson)
+    )
+  }
+
+  test("deleteGoRight") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.deleteGoRight)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(5.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 3, 5).asJson)
+    )
+  }
+
+  test("deleteGoFirst") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.deleteGoFirst)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(1.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 3, 5).asJson)
+    )
+  }
+
+  test("deleteGoLast") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(2))
+      l <- fromResult(a.deleteGoLast)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(5.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 4, 5).asJson)
+    )
+  }
+
+  test("deleteLefts") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.deleteLefts)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(4.asJson) &&
+      result.map(_._2) === Some(List(4, 5).asJson)
+    )
+  }
+
+  test("deleteRights") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.deleteRights)
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(4.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 3, 4).asJson)
+    )
+  }
+
+  test("setLefts") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.setLefts(List(100.asJson, 101.asJson)))
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(4.asJson) &&
+      result.map(_._2) === Some(List(101, 100, 4, 5).asJson)
+    )
+  }
+
+  test("setRights") {
+    val result = for {
+      c <- fromResult(cursor.downField("a"))
+      a <- fromResult(c.downN(3))
+      l <- fromResult(a.setRights(List(100.asJson, 101.asJson)))
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(4.asJson) &&
+      result.map(_._2) === Some(List(1, 2, 3, 4, 100, 101).asJson)
+    )
+  }
+
+  test("deleteGoField") {
+    val result = for {
+      c <- fromResult(cursor.downField("c"))
+      a <- fromResult(c.downField("e"))
+      l <- fromResult(a.deleteGoField("f"))
+      u <- fromResult(l.up)
+      lf <- focus(l)
+      uf <- focus(u)
+    } yield (lf, uf)
+
+    assert(
+      result.map(_._1) === Some(200.2.asJson) &&
+      result.map(_._2) === Some(Map("f" -> 200.2).asJson)
+    )
   }
 }

--- a/core/src/test/scala/io/circe/test/ParserTests.scala
+++ b/core/src/test/scala/io/circe/test/ParserTests.scala
@@ -9,9 +9,6 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.typelevel.discipline.Laws
 
-/**
- * 
- */
 case class ParserLaws(parser: Parser) {
   def parsingRoundTripNoSpaces(json: Json): IsEq[Xor[ParsingFailure, Json]] =
     parser.parse(json.noSpaces) <-> Xor.right(json)

--- a/core/src/test/scala/io/circe/test/PrinterTests.scala
+++ b/core/src/test/scala/io/circe/test/PrinterTests.scala
@@ -1,0 +1,48 @@
+package io.circe.test
+
+import algebra.Eq
+import argonaut.{ DecodeJson, Parse }
+import cats.data.Xor
+import cats.laws._
+import cats.laws.discipline._
+import cats.std.option._
+import io.circe.{ Decoder, DecodingFailure, Encoder, Printer }
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.typelevel.discipline.Laws
+
+trait PrinterLaws[A] {
+  def decode: DecodeJson[A]
+  def encode: Encoder[A]
+
+  def printerRoundTrip(printer: Printer, a: A): IsEq[Option[A]] =
+    Parse.decodeOption(printer.pretty(encode(a)))(decode) <-> Some(a)
+}
+
+object PrinterLaws {
+  def apply[A](implicit d: DecodeJson[A], e: Encoder[A]): PrinterLaws[A] =
+    new PrinterLaws[A] {
+      val decode: DecodeJson[A] = d
+      val encode: Encoder[A] = e
+    }
+}
+
+trait PrinterTests[A] extends Laws {
+  def laws: PrinterLaws[A]
+
+  def printer(printer: Printer)(implicit A: Arbitrary[A], eq: Eq[A]): RuleSet =
+    new DefaultRuleSet(
+      name = "printer",
+      parent = None,
+      "roundTrip" -> Prop.forAll { (a: A) =>
+        isEqToProp(laws.printerRoundTrip(printer, a))
+      }
+    )
+}
+
+object PrinterTests {
+  def apply[A: DecodeJson: Encoder]: PrinterTests[A] =
+    new PrinterTests[A] {
+      val laws: PrinterLaws[A] = PrinterLaws[A]
+    }
+}


### PR DESCRIPTION
This bumps up coverage a bit and fixes some bugs in `Cursor` (these didn't affect any of the provided or derived codecs, but do mean that some operations on zippers were incorrect).