### PR TITLE
Add tests for Java serializability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,6 +137,7 @@ lazy val testsBase = crossProject.in(file("tests"))
   .settings(
     ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages := "io\\.circe\\.tests\\..*"
   )
+  .jvmSettings(fork := true)
   .jsSettings(commonJsSettings: _*)
   .jvmConfigure(_.copy(id = "tests").dependsOn(jawn, async))
   .jsConfigure(_.copy(id = "testsJS"))

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -5,7 +5,7 @@ import cats.data.{ Kleisli, NonEmptyList, Validated, Xor }
 
 import scala.collection.generic.CanBuildFrom
 
-trait Decoder[A] { self =>
+trait Decoder[A] extends Serializable { self =>
   /**
    * Decode the given hcursor.
    */

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable.ArrayBuffer
  *
  * @author Travis Brown
  */
-trait Encoder[A] {
+trait Encoder[A] extends Serializable {
   /**
    * Converts a value to JSON.
    */

--- a/core/shared/src/main/scala/io/circe/GenericCursor.scala
+++ b/core/shared/src/main/scala/io/circe/GenericCursor.scala
@@ -45,7 +45,7 @@ import cats.data.Xor
  *
  * @author Travis Brown
  */
-trait GenericCursor[C <: GenericCursor[C]] {
+trait GenericCursor[C <: GenericCursor[C]] extends Serializable {
   /**
    * The context that the cursor is available in.
    *

--- a/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/core/shared/src/main/scala/io/circe/Parser.scala
@@ -2,7 +2,7 @@ package io.circe
 
 import cats.data.Xor
 
-trait Parser {
+trait Parser extends Serializable {
   def parse(input: String): Xor[ParsingFailure, Json]
 
   def decode[A](input: String)(implicit d: Decoder[A]): Xor[Error, A] =

--- a/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/core/shared/src/main/scala/io/circe/Printer.scala
@@ -46,7 +46,7 @@ final case class Printer(
   objectCommaRight: String = "",
   colonLeft: String = "",
   colonRight: String = ""
-) {
+) extends Serializable {
   private[this] val openBraceText = "{"
   private[this] val closeBraceText = "}"
   private[this] val openArrayText = "["
@@ -148,45 +148,6 @@ final case class Printer(
 
     def trav(depth: Int, k: Json): Unit = {
       val p = pieces(depth)
-
-      /*k.fold(
-        builder.append(nullText),
-        b => builder.append(if (b) trueText else falseText),
-        n => builder.append(n.toString),
-        s => encloseJsonString(s),
-        arr => if (arr.length == 0) builder.append(p.lrEmptyBrackets) else {
-          builder.append(p.lBrackets)
-          trav(depth + 1, arr(0))
-
-          var i = 1
-
-          while (i < arr.length) {
-            builder.append(p.arrayCommas)
-            trav(depth + 1, arr(i))
-            i += 1
-          }
-          builder.append(p.rBrackets)
-        },
-        obj => {
-          builder.append(p.lBraces)
-          val items = if (preserveOrder) obj.toList else obj.toMap
-          var first = true
-
-          items.foreach {
-            case (key, value) =>
-              if (!dropNullKeys || !value.isNull) {
-                if (!first) {
-                  builder.append(p.objectCommas)
-                }
-                encloseJsonString(key)
-                builder.append(p.colons)
-                trav(depth + 1, value)
-                first = false
-              }
-          }
-          builder.append(p.rBraces)
-        }
-      )*/
 
       import Json._
 
@@ -308,9 +269,9 @@ object Printer {
     arrayCommas: String,
     objectCommas: String,
     colons: String
-  )
+  ) extends Serializable
 
-  private[circe] abstract class MemoizedPieces {
+  private[circe] abstract class MemoizedPieces extends Serializable {
     def compute(i: Int): Pieces
 
     private[this] final val known = new java.util.concurrent.CopyOnWriteArrayList[Pieces]

--- a/core/shared/src/main/scala/io/circe/Result.scala
+++ b/core/shared/src/main/scala/io/circe/Result.scala
@@ -1,1 +1,0 @@
-package io.circe


### PR DESCRIPTION
This fixes #45, cleans up some commented code, and adds `Shrink` instances for `Json` and some related types.