### PR TITLE
More laziness in generic codec derivation

### DIFF
--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -35,7 +35,7 @@ trait ArbitraryInstances {
   }
 
   private[this] def arbitraryJsonAtDepth(depth: Int): Arbitrary[Json] = {
-    val genJsons = List( genNumber, genString) ++ (
+    val genJsons = List(genNumber, genString) ++ (
       if (depth < maxDepth) List(genArray(depth), genObject(depth)) else Nil
     )
 


### PR DESCRIPTION
This should fix some issues pointed out recently by @groz and @koshelev on gitter. Both of the new tests fail without the changes in the first commit.

Also fixes #34.