### PR TITLE
Fix StackOverflowError when decoding large JSON arrays

### DIFF
--- a/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -4,6 +4,8 @@ import algebra.Eq
 import cats.data.Xor
 import io.circe.cursor.HCursorOperations
 
+import scala.annotation.tailrec
+
 /**
  * A cursor that tracks the history of operations performed with it.
  *
@@ -45,11 +47,17 @@ case class HCursor(cursor: Cursor, history: List[HistoryOp]) extends HCursorOper
     }
   )
 
-  private[this] final def loop[A, B](
+  @tailrec private[this] final def loop[A, B](
     r1: Decoder.Result[A],
     f: A => Xor[Decoder.Result[B], Decoder.Result[A]]
   ): Decoder.Result[B] =
-    r1.flatMap(a => f(a).swap.valueOr(r2 => loop[A, B](r2, f)))
+    r1 match {
+      case l @ Xor.Left(_) => l
+      case Xor.Right(a) => f(a) match {
+        case Xor.Left(b) => b
+        case Xor.Right(r2) => loop[A, B](r2, f)
+      }
+    }
 }
 
 object HCursor {

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -52,6 +52,18 @@ class StdLibCodecSuite extends CirceSuite {
       }
     }
   }
+
+  test("Decoding a JSON array with many elements into a sequence should not raise StackOverflowError") {
+    val size = 10000
+    val jsonArr = Json.array(Seq.fill(size)(Json.int(1)): _*)
+
+    val maybeList = jsonArr.as[List[Int]]
+    assert(maybeList.isRight)
+
+    val list = maybeList.getOrElse(???)
+    assert(list.length == size)
+    assert(list.forall(_ == 1))
+  }
 }
 
 class CatsCodecSuite extends CirceSuite {


### PR DESCRIPTION
This PR fixes a StackOverflowError raised while decoding large JSON arrays. See the added test, which doesn't pass without this.