### PR TITLE
Add UUID support

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import java.util.UUID
+
 import cats.Monad
 import cats.data.{ Kleisli, NonEmptyList, Validated, Xor }
 
@@ -322,6 +324,20 @@ object Decoder extends TupleDecoders with LowPriorityDecoders {
         case _: NumberFormatException => Xor.left(DecodingFailure("BigDecimal", c.history))
       }
       case _ => Xor.left(DecodingFailure("BigDecimal", c.history))
+    }
+  }
+
+  /**
+   * @group Decoding
+   */
+  implicit val decodeUUID: Decoder[UUID] = instance { c =>
+    c.focus match {
+      case JString(string) if string.length == 36 => try {
+        Xor.right(UUID.fromString(string))
+      } catch {
+        case _: IllegalArgumentException => Xor.left(DecodingFailure("UUID", c.history))
+      }
+      case _ => Xor.left(DecodingFailure("UUID", c.history))
     }
   }
 

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import java.util.UUID
+
 import cats.Foldable
 import cats.data.{ NonEmptyList, Validated, Xor }
 import cats.functor.Contravariant
@@ -160,6 +162,11 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
    * @group Encoding
    */
   implicit val encodeBigDecimal: Encoder[BigDecimal] = instance(a => JsonBigDecimal(a).asJsonOrNull)
+
+  /**
+   * @group Encoding
+   */
+  implicit val encodeUUID: Encoder[UUID] = instance(a => Json.string(a.toString))
 
   /**
    * @group Encoding

--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -1,5 +1,7 @@
 package io.circe.tests
 
+import java.util.UUID
+
 import io.circe.{ Json, JsonBigDecimal, JsonNumber, JsonObject }
 import io.circe.Json.{ JArray, JNumber, JObject, JString }
 import org.scalacheck.{ Arbitrary, Gen, Shrink }
@@ -43,6 +45,8 @@ trait ArbitraryInstances {
   }
 
   implicit def arbitraryJson: Arbitrary[Json] = arbitraryJsonAtDepth(0)
+
+  implicit def arbitraryUUID: Arbitrary[UUID] = Arbitrary(Gen.uuid)
 
   private[this] val minNumberShrink = BigDecimal.valueOf(1L)
   private[this] val zero = BigDecimal.valueOf(0L)

--- a/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -1,11 +1,15 @@
 package io.circe.tests
 
+import java.util.UUID
+
 import algebra.Eq
 import org.scalacheck.Arbitrary
 import shapeless._
 
 trait MissingInstances {
   implicit def eqBigDecimal: Eq[BigDecimal] = Eq.fromUniversalEquals
+
+  implicit def eqUUID: Eq[UUID] = Eq.fromUniversalEquals
 
   implicit def arbitraryTuple1[A](implicit A: Arbitrary[A]): Arbitrary[Tuple1[A]] =
     Arbitrary(A.arbitrary.map(Tuple1(_)))

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import java.util.UUID
+
 import cats.data.{ NonEmptyList, Validated, Xor }
 import cats.laws.discipline.arbitrary._
 import io.circe.tests.{ CodecTests, CirceSuite }
@@ -21,6 +23,7 @@ class StdLibCodecSuite extends CirceSuite {
   checkAll("Codec[String]", CodecTests[String].codec)
   checkAll("Codec[BigInt]", CodecTests[BigInt].codec)
   checkAll("Codec[BigDecimal]", CodecTests[BigDecimal].codec)
+  checkAll("Codec[UUID]", CodecTests[UUID].codec)
   checkAll("Codec[Option[Int]]", CodecTests[Option[Int]].codec)
   checkAll("Codec[List[Int]]", CodecTests[List[Int]].codec)
   checkAll("Codec[Map[String, Int]]", CodecTests[Map[String, Int]].codec)


### PR DESCRIPTION
I was in the middle of migrating the [Todo application](https://github.com/vkostyukov/finch-101/blob/master/src/main/scala/i/f/workshop/finch/Todo.scala) to UUIDs, which are [natively supported in Finch] (https://github.com/finagle/finch/pull/399) and realized there is no encoders/decoders available in Circe for the `java.util.UUID` type.

UUIDs are very very poluar in the modern web so it would be nice to support them out of the box in Circe, given that the decoder implementation [might be tricky](http://mark.koli.ch/thoughts-on-using-raw-uuids-in-your-web-application-or-web-service-paths).

Although, I'd totally understand if UUID codecs is something that's considered as out-of-the-scope of the library. So, please feel free drop this PR if you don't think this should be part of the `core` package.