### PR TITLE
Add tests for incomplete decoders with record keys

### DIFF
--- a/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -33,17 +33,18 @@ package object examples extends AllInstances with ArbitraryInstances with Missin
 }
 
 package examples {
-  case class Qux[A](i: Int, a: A)
+  case class Qux[A](i: Int, a: A, j: Int)
 
   object Qux {
-    implicit def eqQux[A: Eq]: Eq[Qux[A]] = Eq.by(_.a)
+    implicit def eqQux[A: Eq]: Eq[Qux[A]] = Eq.by(q => (q.i, q.a, q.j))
 
     implicit def arbitraryQux[A](implicit A: Arbitrary[A]): Arbitrary[Qux[A]] =
       Arbitrary(
         for {
           i <- Arbitrary.arbitrary[Int]
           a <- A.arbitrary
-        } yield Qux(i, a)
+          j <- Arbitrary.arbitrary[Int]
+        } yield Qux(i, a, j)
       )
   }
 

--- a/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -8,7 +8,7 @@ import io.circe.tests.{ CodecTests, CirceSuite }
 import io.circe.tests.examples._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Prop.forAll
-import shapeless.CNil
+import shapeless.{ CNil, Witness }, shapeless.labelled.{ FieldType, field }
 
 class AutoDerivedSuite extends CirceSuite {
   final case class InnerCaseClassExample(a: String, b: String, c: String, d: String)
@@ -64,21 +64,38 @@ class AutoDerivedSuite extends CirceSuite {
 
   test("Decoder[Int => Qux[String]]") {
     check {
-      forAll { (i: Int, s: String) =>
-        Json.obj("a" -> Json.string(s)).as[Int => Qux[String]].map(_(i)) === Xor.right(Qux(i, s))
+      forAll { (i: Int, s: String, j: Int) =>
+        Json.obj(
+          "a" -> Json.string(s),
+          "j" -> Json.int(j)
+        ).as[Int => Qux[String]].map(_(i)) === Xor.right(Qux(i, s, j))
+      }
+    }
+  }
+
+  test("Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]") {
+    check {
+      forAll { (i: Int, s: String, j: Int) =>
+        Json.obj(
+          "i" -> Json.int(i),
+          "a" -> Json.string(s)
+        ).as[FieldType[Witness.`'j`.T, Int] => Qux[String]].map(
+          _(field(j))
+        ) === Xor.right(Qux(i, s, j))
       }
     }
   }
 
   test("Decoder[Qux[String] => Qux[String]]") {
     check {
-      forAll { (q: Qux[String], i: Option[Int], a: Option[String]) =>
+      forAll { (q: Qux[String], i: Option[Int], a: Option[String], j: Option[Int]) =>
         val json = Json.obj(
           "i" -> Encoder[Option[Int]].apply(i),
-          "a" -> Encoder[Option[String]].apply(a)
+          "a" -> Encoder[Option[String]].apply(a),
+          "j" -> Encoder[Option[Int]].apply(j)
         )
 
-        val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a))
+        val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a), j.getOrElse(q.j))
 
         json.as[Qux[String] => Qux[String]].map(_(q)) === Xor.right(expected)
       }


### PR DESCRIPTION
It's possible to disambiguate between multiple members with the same type when working with incomplete decoders, but this wasn't being tested (or even documented, really, outside of [my initial blog post](https://meta.plasm.us/posts/2015/06/21/deriving-incomplete-type-class-instances/) about the idea).