### PR TITLE
Don't use Travis CI's containerized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 language: scala
 
 scala:


### PR DESCRIPTION
This change slows down the builds, but without it one or two jobs were failing in almost every build, and the error messages are completely unhelpful:

```scala
Exception in thread "Thread-1" Exception in thread "Thread-5" java.io.EOFException
	at java.io.ObjectInputStream$BlockDataInputStream.peekByte(ObjectInputStream.java:2601)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1319)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:371)
	at sbt.React.react(ForkTests.scala:114)
	at sbt.ForkTests$$anonfun$mainTestTask$1$Acceptor$2$.run(ForkTests.scala:74)
	at java.lang.Thread.run(Thread.java:745)
java.io.EOFException
	at java.io.ObjectInputStream$BlockDataInputStream.peekByte(ObjectInputStream.java:2601)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1319)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:371)
	at org.scalatest.tools.Framework$ScalaTestRunner$Skeleton$1$React.react(Framework.scala:808)
	at org.scalatest.tools.Framework$ScalaTestRunner$Skeleton$1.run(Framework.scala:797)
	at java.lang.Thread.run(Thread.java:745)
```

I've tried a number of other fixes, and this is the only one that seems to work.