### PR TITLE
Update to export-hook 1.0.2 and fix #73

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val baseSettings = Seq(
   scalacOptions in (Compile, console) := compilerOptions,
   scalacOptions in (Compile, test) := compilerOptions,
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "export-hook" % "1.0.1",
+    "org.typelevel" %% "export-hook" % "1.0.2",
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
   ),
   resolvers ++= Seq(

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,7 +1,6 @@
 package io.circe.generic
 
-import export.Export
-import io.circe.{ Decoder, ObjectEncoder }
+import export.reexports
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 
@@ -12,11 +11,5 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * instances for tuples, case classes (if all members have instances), "incomplete" case classes,
  * sealed trait hierarchies, etc.
  */
-package object auto {
-  implicit def decoderExports[T](implicit st: DerivedDecoder[T]): Export[Decoder[T]] =
-    DerivedDecoder.exports[Decoder, T]
-
-  implicit def objectEncoderExports[T](implicit
-    st: DerivedObjectEncoder[T]
-  ): Export[ObjectEncoder[T]] = DerivedObjectEncoder.exports[ObjectEncoder, T]
-}
+@reexports[DerivedDecoder, DerivedObjectEncoder]
+object auto

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -20,31 +20,44 @@ object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedD
 
   implicit def decodeCoproduct[K <: Symbol, H, T <: Coproduct](implicit
     key: Witness.Aux[K],
-    decodeHead: Strict[Priority[Decoder[H], DerivedDecoder[H]]],
+    decodeHead: Lazy[Decoder[H]],
     decodeTail: Lazy[DerivedDecoder[T]]
   ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
     def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
       c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
         decodeTail.value(c).map(Inr(_))
       ) { headJson =>
-        headJson.as(decodeHead.value.fold(identity)(identity)).map(h => Inl(field(h)))
+        headJson.as(decodeHead.value).map(h => Inl(field(h)))
       }
   }
   
-  implicit def decodeLabelledHList0[K <: Symbol, H, T <: HList](implicit
+  implicit def decodeLabelledHList[K <: Symbol, H, T <: HList](implicit
     key: Witness.Aux[K],
-    decodeHead: Strict[Priority[Decoder[H], DerivedDecoder[H]]],
+    decodeHead: Lazy[Decoder[H]],
     decodeTail: Lazy[DerivedDecoder[T]]
   ): DerivedDecoder[FieldType[K, H] :: T] = new DerivedDecoder[FieldType[K, H] :: T] {
     def apply(c: HCursor): Decoder.Result[FieldType[K, H] :: T] =
       for {
-        head <- c.get(key.value.name)(decodeHead.value.fold(identity)(identity))
+        head <- c.get(key.value.name)(decodeHead.value)
         tail <- c.as(decodeTail.value)
       } yield field[K](head) :: tail
   }
 }
 
 trait LowPriorityDerivedDecoders {
+  implicit def decodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[DerivedDecoder[H]],
+    decodeTail: Lazy[DerivedDecoder[T]]
+  ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
+    def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
+      c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
+        decodeTail.value(c).map(Inr(_))
+      ) { headJson =>
+        headJson.as(decodeHead.value).map(h => Inl(field(h)))
+      }
+  }
+
   implicit def decodeAdt[A, R <: Coproduct](implicit
     gen: LabelledGeneric.Aux[A, R],
     decode: Lazy[DerivedDecoder[R]]

--- a/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -55,12 +55,28 @@ class AutoDerivedSuite extends CirceSuite {
       Arbitrary(atDepth(0))
   }
 
+  case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
+
+  object RecursiveWithOptionExample {
+    implicit val eqRecursiveWithOptionExample: Eq[RecursiveWithOptionExample] =
+      Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveWithOptionExample] = if (depth < 3)
+      Gen.option(atDepth(depth + 1)).map(
+        RecursiveWithOptionExample(_)
+      ) else Gen.const(RecursiveWithOptionExample(None))
+
+    implicit val arbitraryRecursiveWithOptionExample: Arbitrary[RecursiveWithOptionExample] =
+      Arbitrary(atDepth(0))
+  }
+
   checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
   checkAll("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
   checkAll("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
   checkAll("Codec[Foo]", CodecTests[Foo].codec)
   checkAll("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
   checkAll("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)
+  checkAll("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].codec)
 
   test("Decoder[Int => Qux[String]]") {
     check {


### PR DESCRIPTION
Fixes #73 (and adds a test to verify), so there's now no issue with recursive nesting of types with a mix of derived and non-derived instances:

```scala
scala> import io.circe._, io.circe.jawn.decode, io.circe.generic.auto._
import io.circe._
import io.circe.jawn.decode
import io.circe.generic.auto._

scala> case class Foo(o: Option[Foo])
defined class Foo

scala> decode[Foo]("{}")
res0: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(None))

scala> decode[Foo]("""{ "o": null }""")
res1: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(None))
```

Will update, merge, and publish a new snapshot as soon as export-hook 1.0.2 is published.