### PR TITLE
Initial sketch of generic derivation with default values

### DIFF
--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,7 +1,7 @@
 package io.circe.generic
 
 import export.reexports
-import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.decoding.{ DerivedDecoder, DerivedDecoderWithDefaults }
 import io.circe.generic.encoding.DerivedObjectEncoder
 
 /**
@@ -12,4 +12,7 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * sealed trait hierarchies, etc.
  */
 @reexports[DerivedDecoder, DerivedObjectEncoder]
-object auto
+object auto {
+  @reexports[DerivedDecoderWithDefaults, DerivedObjectEncoder]
+  object defaults
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoderWithDefaults.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoderWithDefaults.scala
@@ -1,0 +1,84 @@
+package io.circe.generic.decoding
+
+import cats.data.Xor
+import io.circe.{ Decoder, DecodingFailure, HCursor }
+import shapeless._, shapeless.labelled.{ FieldType, field }, shapeless.ops.record.Selector
+
+trait DerivedDecoderWithDefaultsBuilder[A, D <: HList] {
+  def apply(d: D): DerivedDecoderWithDefaults[A]
+}
+
+object DerivedDecoderWithDefaultsBuilder extends
+  LowPriorityDerivedDecoderWithDefaultsBuilders {
+    implicit def buildDecoderLabelledHList1[K <: Symbol, H, T <: HList, D <: HList](implicit
+      key: Witness.Aux[K],
+      decodeHead: Lazy[Decoder[H]],
+      decodeTail: Lazy[DerivedDecoderWithDefaultsBuilder[T, D]],
+      sel: Selector.Aux[D, K, H]
+    ): DerivedDecoderWithDefaultsBuilder[FieldType[K, H] :: T, D] =
+      new DerivedDecoderWithDefaultsBuilder[FieldType[K, H] :: T, D] {
+        def apply(d: D): DerivedDecoderWithDefaults[FieldType[K, H] :: T] =
+          new DerivedDecoderWithDefaults[FieldType[K, H] :: T] {
+            def apply(c: HCursor): Decoder.Result[FieldType[K, H] :: T] =
+              c.as(decodeTail.value(d)).map(
+                field[K](c.get(key.value.name)(decodeHead.value).getOrElse(sel(d))) :: _
+              )
+          }
+    }
+  }
+
+private[circe] trait LowPriorityDerivedDecoderWithDefaultsBuilders {
+  implicit def buildDecoderLabelledHList0[K <: Symbol, H, T <: HList, D <: HList](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[Decoder[H]],
+    decodeTail: Lazy[DerivedDecoderWithDefaultsBuilder[T, D]]
+  ): DerivedDecoderWithDefaultsBuilder[FieldType[K, H] :: T, D] =
+    new DerivedDecoderWithDefaultsBuilder[FieldType[K, H] :: T, D] {
+      def apply(d: D): DerivedDecoderWithDefaults[FieldType[K, H] :: T] =
+        new DerivedDecoderWithDefaults[FieldType[K, H] :: T] {
+          def apply(c: HCursor): Decoder.Result[FieldType[K, H] :: T] =
+            for {
+              head <- c.get(key.value.name)(decodeHead.value)
+              tail <- c.as(decodeTail.value(d))
+            } yield field[K](head) :: tail
+        }
+  }
+
+  implicit def fromDerivedDecoderWithDefaults[A, D <: HList](implicit
+    decode: Lazy[DerivedDecoderWithDefaults[A]]
+  ): DerivedDecoderWithDefaultsBuilder[A, D] = new DerivedDecoderWithDefaultsBuilder[A, D] {
+    def apply(defs: D): DerivedDecoderWithDefaults[A] = decode.value
+  }
+}
+
+trait DerivedDecoderWithDefaults[A] extends DerivedDecoder[A]
+
+@export.exports
+object DerivedDecoderWithDefaults extends MidPriorityDerivedDecodersWithDefaults {
+  implicit def decodeCaseClassWithDefaults[A, R <: HList, D <: HList](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    defaults: Default.AsRecord.Aux[A, D],
+    builder: Lazy[DerivedDecoderWithDefaultsBuilder[R, D]]
+  ): DerivedDecoderWithDefaults[A] = new DerivedDecoderWithDefaults[A] {
+    private[this] val decoder = builder.value(defaults()).map(gen.from)
+
+    def apply(c: HCursor): Decoder.Result[A] = decoder(c)
+  }
+}
+
+private[circe] trait MidPriorityDerivedDecodersWithDefaults
+  extends LowPriorityDerivedDecodersWithDefaults {
+    implicit def lowerDerivedDecoder[A](implicit
+      decode: DerivedDecoder[A]
+    ): DerivedDecoderWithDefaults[A] = new DerivedDecoderWithDefaults[A] {
+      def apply(c: HCursor): Decoder.Result[A] = decode(c)
+    }
+  }
+
+private[circe] trait LowPriorityDerivedDecodersWithDefaults {
+  implicit def lowerDecoder[A](implicit
+    decode: Decoder[A]
+  ): DerivedDecoderWithDefaults[A] = new DerivedDecoderWithDefaults[A] {
+    def apply(c: HCursor): Decoder.Result[A] = decode(c)
+  }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -1,10 +1,14 @@
 package io.circe.generic
 
 import io.circe.{ Decoder, HCursor, JsonObject, ObjectEncoder }
-import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.decoding.{
+  DerivedDecoder,
+  DerivedDecoderWithDefaults,
+  DerivedDecoderWithDefaultsBuilder
+}
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.util.PatchWithOptions
-import shapeless.{ HList, LabelledGeneric, Lazy }
+import shapeless.{ HList, Default, LabelledGeneric, Lazy }
 import shapeless.ops.function.FnFromProduct
 import shapeless.ops.record.RemoveAll
 
@@ -50,6 +54,12 @@ object semiauto {
     ): ObjectEncoder[A] = new ObjectEncoder[A] {
       def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
     }
+
+    def decoderWithDefaults[R <: HList, D <: HList](implicit
+      gen: LabelledGeneric.Aux[A, R],
+      defaults: Default.AsRecord.Aux[A, D],
+      builder: Lazy[DerivedDecoderWithDefaultsBuilder[R, D]]
+    ): Decoder[A] = builder.value(defaults()).map(gen.from)
 
     def incomplete[P <: HList, C, T <: HList, R <: HList](implicit
       ffp: FnFromProduct.Aux[P => C, A],

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -26,8 +26,8 @@ import shapeless.ops.record.RemoveAll
  *   case class Foo(i: Int, p: (String, Double))
  *
  *   object Foo {
- *     implicit val decodeFoo: Decoder[Foo] = deriveFor[Foo].decoder
- *     implicit val encodeFoo: Encoder[Foo] = deriveFor[Foo].encoder
+ *     implicit val decodeFoo: Decoder[Foo] = deriveDecoder
+ *     implicit val encodeFoo: Encoder[Foo] = deriveEncoder
  *   }
  * }}}
  */


### PR DESCRIPTION
This needs some work but I wanted to run the API past the people who've been asking for this feature.

It's now possible to derive decoders that will use any available default values for case class members:

```scala
scala> import io.circe.generic.auto.defaults._, io.circe.jawn.decode
import io.circe.generic.auto.defaults._
import io.circe.jawn.decode

scala> case class Foo(a: String, b: Int = 0, c: String, d: Char = 'x')
defined class Foo

scala> decode[Foo]("""{ "a": "X", "c": "Y" }""")
res0: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(X,0,Y,x))

scala> decode[Foo]("""{ "a": "X", "c": "Y", "d": "y" }""")
res1: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(X,0,Y,y))
```

There's also a semi-automatic flavor:

```scala
scala> import io.circe._, io.circe.generic.semiauto._, io.circe.jawn.decode
import io.circe._
import io.circe.generic.semiauto._
import io.circe.jawn.decode

scala> case class Foo(a: String, b: Int = 0, c: String, d: Char = 'x')
defined class Foo

scala> implicit val decodeFoo: Decoder[Foo] = deriveFor[Foo].decoderWithDefaults
decodeFoo: io.circe.Decoder[Foo] = io.circe.Decoder$$anon$2@74e8303d

scala> decode[Foo]("""{ "a": "X", "c": "Y" }""")
res0: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(X,0,Y,x))

scala> decode[Foo]("""{ "a": "X", "c": "Y", "d": "y" }""")
res1: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(X,0,Y,y))
```

There are probably a few `Lazy`s in there that could be removed, and there's still an issue (flagged in a comment in `SemiautoDerivedSuite`) with semi-automatic instances defined in the companion object.