### PR TITLE
Update to cats 0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "0.2.0"
+lazy val catsVersion = "0.3.0-SNAPSHOT"
 lazy val shapelessVersion = "2.3.0-SNAPSHOT"
 
 lazy val baseSettings = Seq(


### PR DESCRIPTION
It [sounds likely](https://github.com/non/cats/issues/594) that cats 0.3.0 will be released in time for circe 0.2.0, so I think it makes sense to go ahead and update to the snapshot.