### PR TITLE
Add spray-json benchmark

### DIFF
--- a/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -51,7 +51,7 @@ class ExampleData {
  *
  * The following command will run the benchmarks with reasonable settings:
  *
- * > sbt "benchmark/run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.EncodingBenchmark"
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.EncodingBenchmark"
  */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -87,7 +87,7 @@ class EncodingBenchmark extends ExampleData {
  *
  * The following command will run the benchmarks with reasonable settings:
  *
- * > sbt "benchmark/run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.DecodingBenchmark"
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.DecodingBenchmark"
  */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -125,7 +125,7 @@ class DecodingBenchmark extends ExampleData {
  *
  * The following command will run the benchmarks with reasonable settings:
  *
- * > sbt "benchmark/run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.ParsingBenchmark"
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.ParsingBenchmark"
  */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -161,7 +161,7 @@ class ParsingBenchmark extends ExampleData {
  *
  * The following command will run the benchmarks with reasonable settings:
  *
- * > sbt "benchmark/run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.PrintingBenchmark"
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.PrintingBenchmark"
  */
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -6,15 +6,18 @@ import io.circe.generic.semiauto._
 import io.circe.jawn._
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
-import play.api.libs.json.{ JsValue, Json => JsonP, Format, Writes }
+import play.api.libs.json.{ JsValue => JsValueP, Json => JsonP, Format, Writes }
+import spray.json.{ JsValue => JsValueS, JsonFormat, JsonWriter, JsonParser => JsonParserS }
+import spray.json.DefaultJsonProtocol._
 
 case class Foo(s: String, d: Double, i: Int, l: Long, bs: List[Boolean])
 
 object Foo {
   implicit val codecFoo: CodecJson[Foo] = CodecJson.derive[Foo]
-  implicit val formatFoo: Format[Foo] = JsonP.format[Foo]
+  implicit val playFormatFoo: Format[Foo] = JsonP.format[Foo]
   implicit val decodeFoo: Decoder[Foo] = deriveFor[Foo].decoder
   implicit val encodeFoo: Encoder[Foo] = deriveFor[Foo].encoder
+  implicit val sprayFormatFoo: JsonFormat[Foo] = jsonFormat5(Foo.apply)
 }
 
 class ExampleData {
@@ -26,15 +29,18 @@ class ExampleData {
 
   @inline def encodeA[A](a: A)(implicit encode: EncodeJson[A]): JsonA = encode(a)
   @inline def encodeC[A](a: A)(implicit encode: Encoder[A]): JsonC = encode(a)
-  @inline def encodeP[A](a: A)(implicit encode: Writes[A]): JsValue = encode.writes(a)
+  @inline def encodeP[A](a: A)(implicit encode: Writes[A]): JsValueP = encode.writes(a)
+  @inline def encodeS[A](a: A)(implicit encode: JsonWriter[A]): JsValueS = encode.write(a)
 
   val intsC: JsonC = encodeC(ints)
   val intsA: JsonA = encodeA(ints)
-  val intsP: JsValue = encodeP(ints)
+  val intsP: JsValueP = encodeP(ints)
+  val intsS: JsValueS = encodeS(ints)
 
   val foosC: JsonC = encodeC(foos)
   val foosA: JsonA = encodeA(foos)
-  val foosP: JsValue = encodeP(foos)
+  val foosP: JsValueP = encodeP(foos)
+  val foosS: JsValueS = encodeS(foos)
 
   val intsJson: String = intsC.noSpaces
   val foosJson: String = foosC.noSpaces
@@ -58,7 +64,10 @@ class EncodingBenchmark extends ExampleData {
   def encodeIntsA: JsonA = encodeA(ints)
 
   @Benchmark
-  def encodeIntsP: JsValue = encodeP(ints)
+  def encodeIntsP: JsValueP = encodeP(ints)
+
+  @Benchmark
+  def encodeIntsS: JsValueS = encodeS(ints)
 
   @Benchmark
   def encodeFoosC: JsonC = encodeC(foos)
@@ -67,7 +76,10 @@ class EncodingBenchmark extends ExampleData {
   def encodeFoosA: JsonA = encodeA(foos)
 
   @Benchmark
-  def encodeFoosP: JsValue = encodeP(foos)
+  def encodeFoosP: JsValueP = encodeP(foos)
+
+  @Benchmark
+  def encodeFoosS: JsValueS = encodeS(foos)
 }
 
 /**
@@ -91,6 +103,9 @@ class DecodingBenchmark extends ExampleData {
   def decodeIntsP: List[Int] = intsP.as[List[Int]]
 
   @Benchmark
+  def decodeIntsS: List[Int] = intsS.convertTo[List[Int]]
+
+  @Benchmark
   def decodeFoosC: Map[String, Foo] =
     foosC.as[Map[String, Foo]].getOrElse(throw new Exception)
 
@@ -100,6 +115,9 @@ class DecodingBenchmark extends ExampleData {
 
   @Benchmark
   def decodeFoosP: Map[String, Foo] = foosP.as[Map[String, Foo]]
+
+  @Benchmark
+  def decodeFoosS: Map[String, Foo] = foosS.convertTo[Map[String, Foo]]
 }
 
 /**
@@ -120,7 +138,10 @@ class ParsingBenchmark extends ExampleData {
   def parseIntsA: JsonA = Parse.parse(intsJson).getOrElse(throw new Exception)
 
   @Benchmark
-  def parseIntsP: JsValue = JsonP.parse(intsJson)
+  def parseIntsP: JsValueP = JsonP.parse(intsJson)
+
+  @Benchmark
+  def parseIntsS: JsValueS = JsonParserS(intsJson)
 
   @Benchmark
   def parseFoosC: JsonC = parse(foosJson).getOrElse(throw new Exception)
@@ -129,7 +150,10 @@ class ParsingBenchmark extends ExampleData {
   def parseFoosA: JsonA = Parse.parse(foosJson).getOrElse(throw new Exception)
 
   @Benchmark
-  def parseFoosP: JsValue = JsonP.parse(foosJson)
+  def parseFoosP: JsValueP = JsonP.parse(foosJson)
+
+  @Benchmark
+  def parseFoosS: JsValueS = JsonParserS(foosJson)
 }
 
 /**
@@ -153,6 +177,9 @@ class PrintingBenchmark extends ExampleData {
   def printIntsP: String = JsonP.stringify(intsP)
 
   @Benchmark
+  def printIntsS: String = intsS.compactPrint
+
+  @Benchmark
   def printFoosC: String = foosC.noSpaces
 
   @Benchmark
@@ -160,4 +187,7 @@ class PrintingBenchmark extends ExampleData {
 
   @Benchmark
   def printFoosP: String = JsonP.stringify(foosP)
+
+  @Benchmark
+  def printFoosS: String = foosS.compactPrint
 }

--- a/benchmark/src/test/scala/io/circe/benchmark/DecodingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/DecodingBenchmarkSpec.scala
@@ -19,6 +19,10 @@ class DecodingBenchmarkSpec extends FlatSpec {
     assert(decodeIntsP === ints)
   }
 
+  it should "correctly decode integers using Spray JSON" in {
+    assert(decodeIntsS === ints)
+  }
+
   it should "correctly decode case classes using Circe" in {
     assert(decodeFoosC === foos)
   }
@@ -29,5 +33,9 @@ class DecodingBenchmarkSpec extends FlatSpec {
 
   it should "correctly decode case classes using Play JSON" in {
     assert(decodeFoosP === foos)
+  }
+
+  it should "correctly decode case classes using Spray JSON" in {
+    assert(decodeFoosS === foos)
   }
 }

--- a/benchmark/src/test/scala/io/circe/benchmark/EncodingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/EncodingBenchmarkSpec.scala
@@ -3,6 +3,9 @@ package io.circe.benchmark
 import argonaut.{ Json => JsonA, _ }, argonaut.Argonaut._
 import org.scalatest.FlatSpec
 import play.api.libs.json.{ Json => JsonP }
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
 
 class EncodingBenchmarkSpec extends FlatSpec {
   val benchmark: EncodingBenchmark = new EncodingBenchmark
@@ -27,6 +30,10 @@ class EncodingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(JsonP.prettyPrint(encodeIntsP)) === Some(ints))
   }
 
+  it should "correctly encode integers using Spray JSON" in {
+    assert(decodeInts(encodeIntsS.compactPrint) === Some(ints))
+  }
+
   it should "correctly encode case classes using Circe" in {
     assert(decodeFoos(encodeFoosC.noSpaces) === Some(foos))
   }
@@ -37,5 +44,9 @@ class EncodingBenchmarkSpec extends FlatSpec {
 
   it should "correctly encode case classes using Play JSON" in {
     assert(decodeFoos(JsonP.prettyPrint(encodeFoosP)) === Some(foos))
+  }
+
+  it should "correctly encode case classes using Spray JSON" in {
+    assert(decodeFoos(encodeFoosS.compactPrint) === Some(foos))
   }
 }

--- a/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
@@ -19,6 +19,10 @@ class ParsingBenchmarkSpec extends FlatSpec {
     assert(parseIntsP === intsP)
   }
 
+  it should "correctly parse integers using Spray JSON" in {
+    assert(parseIntsS === intsS)
+  }
+
   it should "correctly parse case classes using Circe" in {
     assert(parseFoosC === foosC)
   }
@@ -29,5 +33,9 @@ class ParsingBenchmarkSpec extends FlatSpec {
 
   it should "correctly parse case classes using Play JSON" in {
     assert(parseFoosP === foosP)
+  }
+
+  it should "correctly parse case classes using Spray JSON" in {
+    assert(parseFoosS === foosS)
   }
 }

--- a/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
@@ -27,6 +27,10 @@ class PrintingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(printIntsP) === Some(ints))
   }
 
+  it should "correctly print integers using Spray JSON" in {
+    assert(decodeInts(printIntsS) === Some(ints))
+  }
+
   it should "correctly print case classes using Circe" in {
     assert(decodeFoos(printFoosC) === Some(foos))
   }
@@ -37,5 +41,9 @@ class PrintingBenchmarkSpec extends FlatSpec {
 
   it should "correctly print case classes using Play JSON" in {
     assert(decodeFoos(printFoosP) === Some(foos))
+  }
+
+  it should "correctly print case classes using Spray JSON" in {
+    assert(decodeFoos(printFoosS) === Some(foos))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,7 @@ lazy val benchmark = project
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json" % "2.3.10",
       "io.argonaut" %% "argonaut" % "6.1",
+      "io.spray" %% "spray-json" % "1.3.2",
       "org.scalatest" %% "scalatest" % "3.0.0-M9" % "test"
     )
   )


### PR DESCRIPTION
Another point of comparison.

Here are the results from my laptop:

```
info] Benchmark                       Mode  Cnt      Score      Error  Units
[info] DecodingBenchmark.decodeFoosA  thrpt   20   1411,502 ±   62,909  ops/s
[info] DecodingBenchmark.decodeFoosC  thrpt   20   1983,638 ±   72,286  ops/s
[info] DecodingBenchmark.decodeFoosP  thrpt   20   1740,702 ±   21,146  ops/s
[info] DecodingBenchmark.decodeFoosS  thrpt   20   8596,047 ±  146,904  ops/s
[info] DecodingBenchmark.decodeIntsA  thrpt   20   7722,981 ±  208,717  ops/s
[info] DecodingBenchmark.decodeIntsC  thrpt   20  11226,785 ±  665,015  ops/s
[info] DecodingBenchmark.decodeIntsP  thrpt   20  14598,128 ±  144,416  ops/s
[info] DecodingBenchmark.decodeIntsS  thrpt   20  32657,558 ± 2755,072  ops/s
[info] EncodingBenchmark.encodeFoosA  thrpt   20   5493,093 ±   98,725  ops/s
[info] EncodingBenchmark.encodeFoosC  thrpt   20   6198,165 ±   52,079  ops/s
[info] EncodingBenchmark.encodeFoosP  thrpt   20   2230,278 ±   35,819  ops/s
[info] EncodingBenchmark.encodeFoosS  thrpt   20   5196,096 ±   30,894  ops/s
[info] EncodingBenchmark.encodeIntsA  thrpt   20  71120,576 ± 1242,305  ops/s
[info] EncodingBenchmark.encodeIntsC  thrpt   20  88010,821 ± 1199,913  ops/s
[info] EncodingBenchmark.encodeIntsP  thrpt   20  52768,451 ± 4772,556  ops/s
[info] EncodingBenchmark.encodeIntsS  thrpt   20  31652,292 ±  746,873  ops/s
[info] ParsingBenchmark.parseFoosA    thrpt   20   2201,660 ±  209,243  ops/s
[info] ParsingBenchmark.parseFoosC    thrpt   20   2947,012 ±   97,429  ops/s
[info] ParsingBenchmark.parseFoosP    thrpt   20   1781,731 ±   84,997  ops/s
[info] ParsingBenchmark.parseFoosS    thrpt   20   3845,950 ±   60,479  ops/s
[info] ParsingBenchmark.parseIntsA    thrpt   20  10799,199 ±  174,518  ops/s
[info] ParsingBenchmark.parseIntsC    thrpt   20  29738,383 ± 1965,598  ops/s
[info] ParsingBenchmark.parseIntsP    thrpt   20  12330,042 ±  277,252  ops/s
[info] ParsingBenchmark.parseIntsS    thrpt   20  17158,757 ±  342,507  ops/s
[info] PrintingBenchmark.printFoosA   thrpt   20   2725,918 ±  130,361  ops/s
[info] PrintingBenchmark.printFoosC   thrpt   20   3456,312 ±   83,579  ops/s
[info] PrintingBenchmark.printFoosP   thrpt   20   8083,975 ±  187,325  ops/s
[info] PrintingBenchmark.printFoosS   thrpt   20   6461,304 ±  429,615  ops/s
[info] PrintingBenchmark.printIntsA   thrpt   20  13838,824 ±  343,911  ops/s
[info] PrintingBenchmark.printIntsC   thrpt   20  20823,787 ±  423,997  ops/s
[info] PrintingBenchmark.printIntsP   thrpt   20  65957,726 ± 1601,288  ops/s
[info] PrintingBenchmark.printIntsS   thrpt   20  53553,859 ±  934,221  ops/s
```
