### PR TITLE
Use Shapeless 2.2.5 for 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ you can just add the following to your build:
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core" % "0.1.1",
-  "io.circe" %% "circe-generic" % "0.1.1",
-  "io.circe" %% "circe-jawn" % "0.1.1"
+  "io.circe" %% "circe-core" % "0.2.0",
+  "io.circe" %% "circe-generic" % "0.2.0",
+  "io.circe" %% "circe-parse" % "0.2.0"
 )
 ```
 
@@ -28,10 +28,10 @@ Then type `sbt console` to start a REPL and then paste the following (this will 
 root directory of this repository):
 
 ```scala
-scala> import io.circe._, io.circe.generic.auto._, io.circe.jawn._, io.circe.syntax._
+scala> import io.circe._, io.circe.generic.auto._, io.circe.parse._, io.circe.syntax._
 import io.circe._
 import io.circe.generic.auto._
-import io.circe.jawn._
+import io.circe.parse._
 import io.circe.syntax._
 
 scala> sealed trait Foo

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val compilerOptions = Seq(
 )
 
 lazy val catsVersion = "0.2.0"
-lazy val shapelessVersion = "2.3.0-SNAPSHOT"
+lazy val shapelessVersion = "2.2.5"
 
 lazy val baseSettings = Seq(
   scalacOptions ++= compilerOptions ++ (

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Se
   scalacOptions in (ScalaUnidoc, unidoc) ++= Seq("-groups", "-implicits"),
   git.remoteRepo := "git@github.com:travisbrown/circe.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) :=
-    inAnyProject -- inProjects(benchmark, coreJS, genericJS, parseJS, testsJS)
+    inAnyProject -- inProjects(async, benchmark, coreJS, genericJS, parseJS, tests, testsJS)
 )
 
 lazy val root = project.in(file("."))

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -485,4 +485,4 @@ object Decoder extends TupleDecoders with LowPriorityDecoders {
   }
 }
 
-@export.imports[Decoder] trait LowPriorityDecoders
+@export.imports[Decoder] private[circe] trait LowPriorityDecoders

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -250,4 +250,4 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   }
 }
 
-@export.imports[Encoder] trait LowPriorityEncoders
+@export.imports[Encoder] private[circe] trait LowPriorityEncoders

--- a/core/shared/src/main/scala/io/circe/Error.scala
+++ b/core/shared/src/main/scala/io/circe/Error.scala
@@ -10,7 +10,8 @@ case class ParsingFailure(message: String, underlying: Throwable) extends Error 
 }
 
 case class DecodingFailure(message: String, history: List[HistoryOp]) extends Error {
-  override def getMessage: String = message + history.mkString(",")
+  override def getMessage: String =
+    if (history.isEmpty) message else s"$message: ${ history.mkString(",") }"
 
   def withMessage(message: String): DecodingFailure = copy(message = message)
 }

--- a/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -32,4 +32,4 @@ object ObjectEncoder extends LowPriorityObjectEncoders {
   }
 }
 
-@export.imports[ObjectEncoder] trait LowPriorityObjectEncoders
+@export.imports[ObjectEncoder] private[circe] trait LowPriorityObjectEncoders

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,6 +1,7 @@
 package io.circe.generic
 
 import export.reexports
+import io.circe.{ Decoder, Encoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 
@@ -12,4 +13,17 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * sealed trait hierarchies, etc.
  */
 @reexports[DerivedDecoder, DerivedObjectEncoder]
-object auto
+object auto {
+  /**
+   * Blocks derivation until Shapeless #453 is fixed.
+   */
+  implicit def decodeObject0: Decoder[Object] = sys.error("No Decoder[Object]")
+  implicit def decodeObject1: Decoder[Object] = sys.error("No Decoder[Object]")
+  implicit def decodeAnyRef0: Decoder[AnyRef] = sys.error("No Decoder[AnyRef]")
+  implicit def decodeAnyRef1: Decoder[AnyRef] = sys.error("No Decoder[AnyRef]")
+
+  implicit def encodeObject0: Encoder[Object] = sys.error("No Encoder[Object]")
+  implicit def encodeObject1: Encoder[Object] = sys.error("No Encoder[Object]")
+  implicit def encodeAnyRef0: Encoder[AnyRef] = sys.error("No Encoder[AnyRef]")
+  implicit def encodeAnyRef1: Encoder[AnyRef] = sys.error("No Encoder[AnyRef]")
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -44,7 +44,7 @@ object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedD
   }
 }
 
-trait LowPriorityDerivedDecoders {
+private[circe] trait LowPriorityDerivedDecoders {
   implicit def decodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
     key: Witness.Aux[K],
     decodeHead: Lazy[DerivedDecoder[H]],

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
@@ -1,20 +1,18 @@
 package io.circe.generic.decoding
 
 import io.circe.{ Decoder, HCursor }
-import io.circe.generic.util.PatchWithOptions
-import shapeless.{ HList, LabelledGeneric }
-import shapeless.ops.function.FnFromProduct
-import shapeless.ops.record.RemoveAll
+import io.circe.generic.util.{ Complement, PatchWithOptions }
+import shapeless.{ HList, LabelledGeneric }, shapeless.ops.function.FnFromProduct
 
 trait IncompleteDerivedDecoders {
   implicit def decodeIncompleteCaseClass[F, P <: HList, A, T <: HList, R <: HList](implicit
     ffp: FnFromProduct.Aux[P => A, F],
     gen: LabelledGeneric.Aux[A, T],
-    removeAll: RemoveAll.Aux[T, P, (P, R)],
+    complement: Complement.Aux[T, P, R],
     decode: DerivedDecoder[R]
   ): DerivedDecoder[F] = new DerivedDecoder[F] {
     def apply(c: HCursor): Decoder.Result[F] =
-      decode(c).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
+      decode(c).map(r => ffp(p => gen.from(complement.insert(p, r))))
   }
 
   implicit def decodeCaseClassPatch[A, R <: HList, O <: HList](implicit

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
@@ -4,7 +4,7 @@ import io.circe.{ Decoder, HCursor }
 import io.circe.generic.util.{ Complement, PatchWithOptions }
 import shapeless.{ HList, LabelledGeneric }, shapeless.ops.function.FnFromProduct
 
-trait IncompleteDerivedDecoders {
+private[circe] trait IncompleteDerivedDecoders {
   implicit def decodeIncompleteCaseClass[F, P <: HList, A, T <: HList, R <: HList](implicit
     ffp: FnFromProduct.Aux[P => A, F],
     gen: LabelledGeneric.Aux[A, T],

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -46,7 +46,7 @@ object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
     }
 }
 
-trait LowPriorityDerivedObjectEncoders {
+private[circe] trait LowPriorityDerivedObjectEncoders {
   implicit def encodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
     key: Witness.Aux[K],
     encodeHead: Lazy[DerivedObjectEncoder[H]],

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -3,10 +3,8 @@ package io.circe.generic
 import io.circe.{ Decoder, HCursor, JsonObject, ObjectEncoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
-import io.circe.generic.util.PatchWithOptions
-import shapeless.{ HList, LabelledGeneric, Lazy }
-import shapeless.ops.function.FnFromProduct
-import shapeless.ops.record.RemoveAll
+import io.circe.generic.util.{ Complement, PatchWithOptions }
+import shapeless.{ HList, LabelledGeneric, Lazy }, shapeless.ops.function.FnFromProduct
 
 /**
  * Semi-automatic codec derivation.
@@ -48,7 +46,7 @@ object semiauto {
     def incomplete[P <: HList, C, T <: HList, R <: HList](implicit
       ffp: FnFromProduct.Aux[P => C, A],
       gen: LabelledGeneric.Aux[C, T],
-      removeAll: RemoveAll.Aux[T, P, (P, R)],
+      complement: Complement.Aux[T, P, R],
       decode: DerivedDecoder[R]
     ): Decoder[A] = DerivedDecoder.decodeIncompleteCaseClass[A, P, C, T, R]
 

--- a/generic/shared/src/main/scala/io/circe/generic/util/Complement.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/util/Complement.scala
@@ -1,0 +1,89 @@
+package io.circe.generic.util
+
+import shapeless._
+import shapeless.labelled.{ FieldType, field }
+
+/**
+ * Supports removal and insertion of an element (possibly unlabeled) into an `HList`.
+ *
+ * @author Travis Brown
+ */
+trait Insert[L <: HList, E] extends DepFn1[L] with Serializable {
+  def insert(e: E, out: Out): L
+}
+
+trait LowPriorityInsert {
+  type Aux[L <: HList, E, Out0] = Insert[L, E] {
+    type Out = Out0
+  }
+
+  implicit def insertTail[H, T <: HList, E, OutT <: HList](implicit
+    insertT: Aux[T, E, OutT]
+  ): Aux[H :: T, E, H :: OutT] = new Insert[H :: T, E] {
+    type Out = H :: OutT
+
+    def apply(l: H :: T): Out = l.head :: insertT(l.tail)
+    def insert(e: E, out: H :: OutT): H :: T =
+      out.head :: insertT.insert(e, out.tail)
+  }
+}
+
+object Insert extends LowPriorityInsert {
+  def apply[L <: HList, E](implicit
+    insert: Insert[L, E]
+  ): Aux[L, E, insert.Out] = insert
+
+  implicit def insertHead[H, T <: HList]: Aux[H :: T, H, T] =
+    new Insert[H :: T, H] {
+      type Out = T
+
+      def apply(l: H :: T): Out = l.tail
+      def insert(e: H, out: T): H :: T = e :: out
+    }
+
+  implicit def insertUnlabeledHead[H, K, T <: HList]: Aux[FieldType[K, H] :: T, H, T] =
+    new Insert[FieldType[K, H] :: T, H] {
+      type Out = T
+
+      def apply(l: FieldType[K, H] :: T): Out = l.tail
+      def insert(e: H, out: T): FieldType[K, H] :: T = field[K](e) :: out
+    }
+}
+
+/**
+ * Supports removal and insertion of an `HList` of elements (possibly unlabeled) into an `HList`.
+ *
+ * @author Travis Brown
+ */
+trait Complement[L <: HList, A <: HList] extends DepFn1[L] {
+  def insert(a: A, out: Out): L
+}
+
+object Complement {
+  type Aux[L <: HList, A <: HList, Out0] = Complement[L, A] {
+    type Out = Out0
+  }
+
+  def apply[L <: HList, A <: HList](implicit
+    complement: Complement[L, A]
+  ): Aux[L, A, complement.Out] = complement
+
+  implicit def hnilCompl[L <: HList]: Aux[L, HNil, L] =
+    new Complement[L, HNil] {
+      type Out = L
+
+      def apply(l: L): L = l
+      def insert(a: HNil, out: L): L = out
+    }
+
+  implicit def hconsCompl[L <: HList, H, T <: HList, OutT <: HList](implicit
+    complementT: Complement.Aux[L, T, OutT],
+    insertH: Insert[OutT, H]
+  ): Aux[L, H :: T, insertH.Out] = new Complement[L, H :: T] {
+    type Out = insertH.Out
+
+    def apply(l: L): insertH.Out = insertH(complementT(l))
+    def insert(a: H :: T, out: insertH.Out): L =
+      complementT.insert(a.tail, insertH.insert(a.head, out))
+  }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/util/Complement.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/util/Complement.scala
@@ -12,7 +12,7 @@ trait Insert[L <: HList, E] extends DepFn1[L] with Serializable {
   def insert(e: E, out: Out): L
 }
 
-trait LowPriorityInsert {
+private[circe] trait LowPriorityInsert {
   type Aux[L <: HList, E, Out0] = Insert[L, E] {
     type Out = Out0
   }

--- a/tests/shared/src/test/scala/io/circe/generic/util/ComplementSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/util/ComplementSuite.scala
@@ -1,0 +1,43 @@
+package io.circe.generic.util
+
+import io.circe.tests.CirceSuite
+import org.scalacheck.Prop.forAll
+import shapeless.{ test => _, _ }, shapeless.record._, shapeless.syntax.singleton._
+
+class ComplementSuite extends CirceSuite {
+  type R = Record.`'i -> Int, 's -> String, 'c -> Char`.T
+
+  test("Remove and reinsert labeled elements") {
+    check {
+      forAll { (i: Int, s: String, c: Char) =>
+        type A = Record.`'i -> Int, 's -> String`.T
+        type L = Record.`'c -> Char`.T
+
+        val r = 'i ->> i :: 's ->> s :: 'c ->> c :: HNil
+
+        val leftover: L = Complement[R, A].apply(r)
+        val recovered: R = Complement[R, A].insert('i ->> i :: 's ->> s :: HNil, leftover)
+
+        leftover('c) === c &&
+          recovered('i) === r('i) && recovered('s) === r('s) && recovered('c) === r('c)
+      }
+    }
+  }
+
+  test("Remove and reinsert unlabeled elements") {
+    check {
+      forAll { (i: Int, s: String, c: Char) =>
+        type A = Int :: String :: HNil
+        type L = Record.`'c -> Char`.T
+
+        val r = 'i ->> i :: 's ->> s :: 'c ->> c :: HNil
+
+        val leftover: L = Complement[R, A].apply(r)
+        val recovered: R = Complement[R, A].insert(i :: s :: HNil, leftover)
+
+        leftover('c) === c &&
+          recovered('i) === r('i) && recovered('s) === r('s) && recovered('c) === r('c)
+      }
+    }
+  }
+}


### PR DESCRIPTION
After publishing 0.1.2 this morning I realized that after some recent changes to `generic` and the upgrade to export-hook 1.0.2, we no longer absolutely need new changes in Shapeless 2.3.0.

The changes here would allow us to publish circe 0.2.0 today against cats 0.2.0 and Shapeless 2.2.5. We'd then be able to spend some time with the bigger changes in #78, #79, and #85 and publish them in circe 0.3.0 when Shapeless 2.3.0 and cats 0.3.0 are available.

I hadn't fixed #55 and #57 because I was expecting them to be resolved when Shapeless's [#453](https://github.com/milessabin/shapeless/issues/453) is closed, but if we're publishing 0.2.0 against Shapeless 2.2.5 it makes sense to fix them now (so I did). If we go this route I'll open an issue about removing the ambiguous instances before 0.3.0