### PR TITLE
preserve field order when printing

### DIFF
--- a/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/core/shared/src/main/scala/io/circe/Printer.scala
@@ -206,13 +206,17 @@ object Printer {
   /**
    * A pretty-printer configuration that inserts no spaces.
    */
-  final val noSpaces: Printer = Printer(false, false, "")
+  final val noSpaces: Printer = Printer(
+    preserveOrder = true,
+    dropNullKeys = false,
+    indent = ""
+  )
 
   /**
    * A pretty-printer configuration that indents by the given spaces.
    */
   final def indented(indent: String): Printer = Printer(
-    preserveOrder = false,
+    preserveOrder = true,
     dropNullKeys = false,
     indent = indent,
     lbraceRight = "\n",


### PR DESCRIPTION
This PR addresses #88 and defaults printing to preserve field order. I went ahead and flagged it the same for spaces/no spaces for consistency but that can be up for discussion if anyone feels otherwise.