### PR TITLE
Add derived vs. non-derived benchmark

### DIFF
--- a/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -1,5 +1,6 @@
 package io.circe.benchmark
 
+import algebra.Eq
 import argonaut.{ Json => JsonA, _ }, argonaut.Argonaut._
 import io.circe.{ Decoder, Encoder, Json => JsonC }
 import io.circe.generic.semiauto._
@@ -18,6 +19,8 @@ object Foo {
   implicit val decodeFoo: Decoder[Foo] = deriveFor[Foo].decoder
   implicit val encodeFoo: Encoder[Foo] = deriveFor[Foo].encoder
   implicit val sprayFormatFoo: JsonFormat[Foo] = jsonFormat5(Foo.apply)
+
+  implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals[Foo]
 }
 
 class ExampleData {
@@ -190,4 +193,63 @@ class PrintingBenchmark extends ExampleData {
 
   @Benchmark
   def printFoosS: String = foosS.compactPrint
+}
+
+/**
+ * Compare the performance of derived and non-derived codecs.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/jmh:run -i 10 -wi 10 -f 2 -t 1 io.circe.benchmark.CirceDerivationBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class CirceDerivationBenchmark {
+  import io.circe._
+
+  private[this] val derivedDecoder: Decoder[Foo] = deriveFor[Foo].decoder
+  private[this] val derivedEncoder: Encoder[Foo] = deriveFor[Foo].encoder
+
+  private[this] val nonDerivedDecoder: Decoder[Foo] = new Decoder[Foo] {
+    def apply(c: HCursor): Decoder.Result[Foo] = for {
+      s <- c.get[String]("s")
+      d <- c.get[Double]("d")
+      i <- c.get[Int]("i")
+      l <- c.get[Long]("l")
+      bs <- c.get[List[Boolean]]("bs")
+    } yield Foo(s, d, i, l, bs)
+  }
+
+  private[this] val nonDerivedEncoder: Encoder[Foo] = new Encoder[Foo] {
+    def apply(foo: Foo): Json = Json.obj(
+      "s" -> Encoder[String].apply(foo.s),
+      "d" -> Encoder[Double].apply(foo.d),
+      "i" -> Encoder[Int].apply(foo.i),
+      "l" -> Encoder[Long].apply(foo.l),
+      "bs" -> Encoder[List[Boolean]].apply(foo.bs)
+    )
+  }
+
+  val exampleFoo: Foo = Foo(
+    "abcdefghijklmnopqrstuvwxyz",
+    1001.0,
+    2002,
+    3003L,
+    List(true, false, true, false, true, false, true, false, true)
+  )
+
+  val exampleFooJson = Encoder[Foo].apply(exampleFoo)
+
+  @Benchmark
+  def decodeDerived: Decoder.Result[Foo] = derivedDecoder.decodeJson(exampleFooJson)
+
+  @Benchmark
+  def decodeNonDerived: Decoder.Result[Foo] = nonDerivedDecoder.decodeJson(exampleFooJson)
+
+  @Benchmark
+  def encodeDerived: Json = derivedEncoder(exampleFoo)
+
+  @Benchmark
+  def encodeNonDerived: Json = nonDerivedEncoder(exampleFoo)
 }

--- a/benchmark/src/test/scala/io/circe/benchmark/CirceDerivationBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/CirceDerivationBenchmarkSpec.scala
@@ -1,0 +1,26 @@
+package io.circe.benchmark
+
+import cats.data.Xor
+import org.scalatest.FlatSpec
+
+class CirceDerivationBenchmarkSpec extends FlatSpec {
+  val benchmark: CirceDerivationBenchmark = new CirceDerivationBenchmark
+
+  import benchmark._
+
+  "The derived codecs" should "correctly decode Foos" in {
+    assert(decodeDerived === Xor.right(exampleFoo))
+  }
+
+  it should "correctly encode Foos" in {
+    assert(encodeDerived === exampleFooJson)
+  }
+
+  "The non-derived codecs" should "correctly decode Foos" in {
+    assert(decodeNonDerived === Xor.right(exampleFoo))
+  }
+
+  it should "correctly encode Foos" in {
+    assert(encodeNonDerived === exampleFooJson)
+  }
+}


### PR DESCRIPTION
I've been meaning to add a benchmark comparing derived and non-derived codecs for a while, and [this question](https://gitter.im/milessabin/shapeless?at=563fd2b63264958d1dc6034d) from @adelbertc was a good reminder.

The non-derived decoders and encoders are intended to be idiomatic, and one of the interesting things the benchmarks show is that `Json.obj` (used in the non-derived encoder but not the derived one) needs some work—the derived encoder is actually faster than the hand-written one. The throughput of the derived decoder is about 3% lower than the non-derived one, which is within the margin of error.

```
Benchmark                                   Mode  Cnt        Score       Error  Units
CirceDerivationBenchmark.decodeDerived     thrpt   80   788832.569 ± 11653.684  ops/s
CirceDerivationBenchmark.decodeNonDerived  thrpt   80   813443.980 ± 13189.326  ops/s
CirceDerivationBenchmark.encodeDerived     thrpt   80  1010433.746 ± 12266.961  ops/s
CirceDerivationBenchmark.encodeNonDerived  thrpt   80   975425.816 ±  9003.887  ops/s
```

The derived decoders and encoders also look pretty good in terms of allocations:

```
Benchmark                                                       Mode  Cnt        Score       Error   Units
CirceDerivationBenchmark.decodeDerived:gc.alloc.rate.norm      thrpt   20     4984.002 ±    35.636    B/op
CirceDerivationBenchmark.decodeNonDerived:gc.alloc.rate.norm   thrpt   20     4844.002 ±   110.473    B/op
CirceDerivationBenchmark.encodeDerived:gc.alloc.rate.norm      thrpt   20     2752.002 ±     0.003    B/op
CirceDerivationBenchmark.encodeNonDerived:gc.alloc.rate.norm   thrpt   20     2992.002 ±     0.003    B/op
```

So performance probably isn't usually a good reason to avoid generic derivation here.
