### PR TITLE
Fix printing null strings

### DIFF
--- a/core/shared/src/main/scala/io/circe/Printer.scala
+++ b/core/shared/src/main/scala/io/circe/Printer.scala
@@ -170,7 +170,9 @@ final case class Printer(
               }
           }
           builder.append(p.rBraces)
-        case JString(s) => encloseJsonString(s)
+        case JString(s) =>
+          if (s == null) builder.append(nullText)
+          else encloseJsonString(s)
         case JNumber(n) => n match {
           case JsonLong(x) => builder.append(x.toString)
           case JsonDouble(x) => builder.append(x.toString)

--- a/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -3,6 +3,7 @@ package io.circe.tests
 import io.circe.{ Parser, Printer }
 
 class PrinterSuite(printer: Printer, parser: Parser) extends CirceSuite {
+  checkAll("Printing String", PrinterTests[String].printer(printer, parser))
   checkAll("Printing Unit", PrinterTests[Unit].printer(printer, parser))
   checkAll("Printing Boolean", PrinterTests[Boolean].printer(printer, parser))
   checkAll("Printing Char", PrinterTests[Char].printer(printer, parser))


### PR DESCRIPTION
This PR fixes a bug discussed [on Gitter](https://gitter.im/travisbrown/circe?at=56417d9404a883da3838cea4):

Before:

```scala
scala> case class Foo(s: String)
defined class Foo

scala> Foo(null).asJson.noSpaces
java.lang.NullPointerException
  at scala.collection.immutable.StringOps$.length$extension(StringOps.scala:48)
  at scala.collection.immutable.StringOps.length(StringOps.scala:48)
````

After:

```scala
scala> case class Foo(s: String)
defined class Foo

scala> Foo(null).asJson.noSpaces
res0: String = {"s":null}
```

Please note that I'm not quite sure this the right place for the fix.