### PR TITLE
Change root project name to circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Se
     inAnyProject -- inProjects(async, benchmark, coreJS, genericJS, parseJS, tests, testsJS)
 )
 
-lazy val root = project.in(file("."))
+lazy val circe = project.in(file("."))
   .settings(allSettings)
   .settings(docSettings)
   .settings(noPublishSettings)


### PR DESCRIPTION
As the root SBT project is currently called `root`, this gives circe the name `root` in IntelliJ. This PR changes that.