### PR TITLE
Remove type-safe equality methods (in favor of Eq syntax)

### DIFF
--- a/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -92,16 +92,6 @@ sealed abstract class JsonObject extends Serializable {
    * Return the number of associations.
    */
   def size: Int
-
-  /**
-   * Type-safe equality for [[JsonObject]].
-   */
-  def ===(that: JsonObject): Boolean = this.toMap == that.toMap
-
-  /**
-   * Type-safe inequality for [[JsonObject]].
-   */
-  def =!=(that: JsonObject): Boolean = !(this === that)
 }
 
 /**
@@ -210,11 +200,10 @@ object JsonObject {
     /**
      * Universal equality derived from our type-safe equality.
      */
-    override def equals(o: Any) =
-      o match {
-        case j: JsonObject => this === j
-        case _ => false
-      }
+    override def equals(that: Any) = that match {
+      case that: JsonObject => JsonObject.eqJsonObject.eqv(this, that)
+      case _ => false
+    }
 
     override def hashCode = fieldMap.hashCode
   }


### PR DESCRIPTION
This is the change proposed [here](https://gitter.im/travisbrown/circe?at=5644ea60bb11d0727958ba77):

> circe currently defines === and =!= methods for a few core types, and then defines their Eq instances in terms of these methods. These collide with the syntax methods provided by cats.syntax.EqOps, which is mildly inconsistent / surprising.
>
> I'm thinking of removing them outright in 0.3.0, without a deprecation cycle, and doing everything in terms of the Eq instances. If you want === and =!=, you can get them via syntactic extensions (just like for any other type with an Eq). Any objections?

One other issue worth noting is that there's some redundancy in the `JsonObject` case, where `===` and the `Eq` instance are only accidentally consistent. This could be fixed independently, but I think it makes more sense to get rid of `===` altogether.