### PR TITLE
Rename some symbolic operators

### DIFF
--- a/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -67,7 +67,13 @@ case class ACursor(either: Xor[HCursor, HCursor]) extends ACursorOperations {
   /**
    * Return the current cursor or the given one if this one isn't successful.
    */
-  def |||(c: => ACursor): ACursor = if (succeeded) this else c
+  def or(c: => ACursor): ACursor = if (succeeded) this else c
+
+  /**
+   * Return the current cursor or the given one if this one isn't successful.
+   */
+  @deprecated("Use or", "0.3.0")
+  def |||(c: => ACursor): ACursor = or(c)
 
   /**
    * Return a [[cats.data.Validated]] of the underlying cursor.

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -71,7 +71,7 @@ trait Decoder[A] extends Serializable { self =>
   /**
    * Combine two decoders.
    */
-  def &&&[B](x: Decoder[B]): Decoder[(A, B)] = Decoder.instance(c =>
+  def and[B](x: Decoder[B]): Decoder[(A, B)] = Decoder.instance(c =>
     for {
       a <- this(c)
       b <- x(c)
@@ -79,12 +79,24 @@ trait Decoder[A] extends Serializable { self =>
   )
 
   /**
+   * Combine two decoders.
+   */
+  @deprecated("Use and", "0.3.0")
+  def &&&[B](x: Decoder[B]): Decoder[(A, B)] = and(x)
+
+  /**
    * Choose the first succeeding decoder.
    */
-  def |||[AA >: A](d: => Decoder[AA]): Decoder[AA] = Decoder.instance[AA] { c =>
+  def or[AA >: A](d: => Decoder[AA]): Decoder[AA] = Decoder.instance[AA] { c =>
     val res = apply(c).map(a => (a: AA))
     res.fold(_ => d(c), _ => res)
   }
+
+  /**
+   * Choose the first succeeding decoder.
+   */
+  @deprecated("Use or", "0.3.0")
+  def |||[AA >: A](d: => Decoder[AA]): Decoder[AA] = or(d)
 
   /**
    * Run one or another decoder.

--- a/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -19,19 +19,31 @@ sealed abstract class JsonObject extends Serializable {
   def toMap: Map[String, Json]
 
   /**
-   * Insert the given association.
+   * Insert the given key-value pair.
    */
-  def +(k: String, j: Json): JsonObject
+  def add(k: String, j: Json): JsonObject
 
   /**
-   * Prepend the given association.
+   * Insert the given key-value pair.
+   */
+  @deprecated("Use add", "0.3.0")
+  def +(k: String, j: Json): JsonObject  = add(k, j)
+
+  /**
+   * Prepend the given key-value pair.
    */
   def +:(f: (String, Json)): JsonObject
 
   /**
-   * Remove the given field association.
+   * Remove the field with the given key (if it exists).
    */
-  def -(k: String): JsonObject
+  def remove(k: String): JsonObject
+
+  /**
+   * Remove the field with the given key (if it exists).
+   */
+  @deprecated("Use remove", "0.3.0")
+  def -(k: String): JsonObject = remove(k)
 
   /**
    * Return the JSON value associated with the given field.
@@ -102,7 +114,7 @@ object JsonObject {
    * Construct a [[JsonObject]] from a foldable collection of key-value pairs.
    */
   def from[F[_]](f: F[(String, Json)])(implicit F: Foldable[F]): JsonObject =
-    F.foldLeft(f, empty) { case (acc, (k, v)) => acc + (k, v) }
+    F.foldLeft(f, empty) { case (acc, (k, v)) => acc.add(k, v) }
 
   /**
    * Construct a [[JsonObject]] from an [[scala.collection.IndexedSeq]] (provided for optimization).
@@ -153,7 +165,7 @@ object JsonObject {
   ) extends JsonObject {
     def toMap: Map[String, Json] = fieldMap
 
-    def +(k: String, j: Json): JsonObject =
+    def add(k: String, j: Json): JsonObject =
       if (fieldMap.contains(k)) {
         copy(fieldMap = fieldMap.updated(k, j))
       } else {
@@ -169,7 +181,7 @@ object JsonObject {
       }
     }
 
-    def -(k: String): JsonObject =
+    def remove(k: String): JsonObject =
       copy(fieldMap = fieldMap - k, orderedFields = orderedFields.filterNot(_ == k))
 
     def apply(k: String): Option[Json] = fieldMap.get(k)

--- a/core/shared/src/main/scala/io/circe/cursor/CArray.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CArray.scala
@@ -21,7 +21,7 @@ private[circe] case class CArray(
       case o: CObject => o.copy(
         focus = newFocus,
         changed = self.changed || o.changed,
-        obj = if (self.changed) o.obj + (o.key, newFocus) else o.obj
+        obj = if (self.changed) o.obj.add(o.key, newFocus) else o.obj
       )
     }
   }

--- a/core/shared/src/main/scala/io/circe/cursor/CObject.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CObject.scala
@@ -13,7 +13,7 @@ private[circe] case class CObject(
   def context: List[Context] = Context.inObject(focus, key) :: parent.context
 
   def up: Option[Cursor] = Some {
-    val newFocus = Json.fromJsonObject(if (changed) obj + (key, focus) else obj)
+    val newFocus = Json.fromJsonObject(if (changed) obj.add(key, focus) else obj)
 
     parent match {
       case _: CJson => CJson(newFocus)
@@ -23,7 +23,7 @@ private[circe] case class CObject(
   }
 
   def delete: Option[Cursor] = Some {
-    val newFocus = Json.fromJsonObject(obj - key)
+    val newFocus = Json.fromJsonObject(obj.remove(key))
 
     parent match {
       case _: CJson => CJson(newFocus)
@@ -41,6 +41,6 @@ private[circe] case class CObject(
   }
 
   override def deleteGoField(k: String): Option[Cursor] = obj(k).map { newFocus =>
-    copy(focus = newFocus, key = k, changed = true, obj = obj - key)
+    copy(focus = newFocus, key = k, changed = true, obj = obj.remove(key))
   }
 }

--- a/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
@@ -27,12 +27,12 @@ private[circe] trait CursorOperations extends GenericCursor[Cursor] { this: Curs
             case o: CObject => o.copy(
               focus = newFocus,
               changed = changed || o.changed,
-              obj = if (changed) o.obj + (o.key, newFocus) else o.obj
+              obj = if (changed) o.obj.add(o.key, newFocus) else o.obj
             )
           }
         )
       case CObject(j, k, p, changed, obj) =>
-        val newFocus = Json.fromJsonObject(if (changed) obj + (k, j) else obj)
+        val newFocus = Json.fromJsonObject(if (changed) obj.add(k, j) else obj)
 
         go(
           p match {


### PR DESCRIPTION
I'm not a big fan of symbolic operators, and in a couple of these cases I think they present opportunities for confusion (e.g. why does `(k -> v) +: o` work but not `o + (k -> v)`?), or that they obscure the API (I've had a couple of people say they didn't realize something that there was a method that does what `|||` does for decoders).

If anyone wants to advocate for any of these, I'm happy to discuss removing the deprecations, but otherwise I'd like to remove them in 0.4.0.