### PR TITLE
Add circe-jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ other libraries.
 circe doesn't include a JSON parser in the `core` project, which is focused on the JSON AST, zippers,
 and codecs. The [`jawn`][circe-jawn] subproject provides support for parsing JSON via a [Jawn][jawn]
 facade. Jawn is fast, it offers asynchronous parsing, and best of all it lets us drop a lot of the
-fussiest code in Argonaut.
+fussiest code in Argonaut. The [`jackson`][circe-jackson] subproject supports using
+[Jackson][jackson] for both parsing and printing.
 
 circe also provides a [`parse`][circe-parse] subproject that provides parsing support for Scala.js,
 with JVM parsing provided by `io.circe.jawn` and JavaScript parsing from `scalajs.js.JSON`.
@@ -356,6 +357,7 @@ limitations under the License.
 [benchmarks]: https://github.com/travisbrown/circe/blob/topic/plugins/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
 [cats]: https://github.com/non/cats
 [circe-generic]: https://travisbrown.github.io/circe/api/#io.circe.generic.auto$
+[circe-jackson]: https://travisbrown.github.io/circe/api/#io.circe.jackson.package
 [circe-jawn]: https://travisbrown.github.io/circe/api/#io.circe.jawn.package
 [circe-parse]: https://travisbrown.github.io/circe/api/#io.circe.parse.package
 [code-of-conduct]: http://typelevel.org/conduct.html
@@ -366,6 +368,7 @@ limitations under the License.
 [generic-cursor]: https://travisbrown.github.io/circe/api/#io.circe.GenericCursor
 [gitter]: https://gitter.im/travisbrown/circe
 [incompletes]: https://meta.plasm.us/posts/2015/06/21/deriving-incomplete-type-class-instances/
+[jackson]: https://github.com/FasterXML/jackson
 [jawn]: https://github.com/non/jawn
 [markhibberd]: https://github.com/markhibberd
 [maven-central]: http://search.maven.org/

--- a/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -138,6 +138,9 @@ class ParsingBenchmark extends ExampleData {
   def parseIntsC: JsonC = parse(intsJson).getOrElse(throw new Exception)
 
   @Benchmark
+  def parseIntsCJ: JsonC = io.circe.jackson.parse(intsJson).getOrElse(throw new Exception)
+
+  @Benchmark
   def parseIntsA: JsonA = Parse.parse(intsJson).getOrElse(throw new Exception)
 
   @Benchmark
@@ -148,6 +151,9 @@ class ParsingBenchmark extends ExampleData {
 
   @Benchmark
   def parseFoosC: JsonC = parse(foosJson).getOrElse(throw new Exception)
+
+  @Benchmark
+  def parseFoosCJ: JsonC = io.circe.jackson.parse(foosJson).getOrElse(throw new Exception)
 
   @Benchmark
   def parseFoosA: JsonA = Parse.parse(foosJson).getOrElse(throw new Exception)
@@ -174,6 +180,9 @@ class PrintingBenchmark extends ExampleData {
   def printIntsC: String = intsC.noSpaces
 
   @Benchmark
+  def printIntsCJ: String = io.circe.jackson.jacksonPrint(intsC)
+
+  @Benchmark
   def printIntsA: String = intsA.nospaces
 
   @Benchmark
@@ -184,6 +193,9 @@ class PrintingBenchmark extends ExampleData {
 
   @Benchmark
   def printFoosC: String = foosC.noSpaces
+
+  @Benchmark
+  def printFoosCJ: String = io.circe.jackson.jacksonPrint(foosC)
 
   @Benchmark
   def printFoosA: String = foosA.nospaces

--- a/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/ParsingBenchmarkSpec.scala
@@ -11,6 +11,10 @@ class ParsingBenchmarkSpec extends FlatSpec {
     assert(parseIntsC === intsC)
   }
 
+  it should "correctly parse integers using Circe with Jackson" in {
+    assert(parseIntsCJ === intsC)
+  }
+
   it should "correctly parse integers using Argonaut" in {
     assert(parseIntsA === intsA)
   }
@@ -25,6 +29,10 @@ class ParsingBenchmarkSpec extends FlatSpec {
 
   it should "correctly parse case classes using Circe" in {
     assert(parseFoosC === foosC)
+  }
+
+  it should "correctly parse case classes using Circe with Jackson" in {
+    assert(parseFoosCJ === foosC)
   }
 
   it should "correctly parse case classes using Argonaut" in {

--- a/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/circe/benchmark/PrintingBenchmarkSpec.scala
@@ -19,6 +19,10 @@ class PrintingBenchmarkSpec extends FlatSpec {
     assert(decodeInts(printIntsC) === Some(ints))
   }
 
+  it should "correctly print integers using Circe with Jackson" in {
+    assert(decodeInts(printIntsCJ) === Some(ints))
+  }
+
   it should "correctly print integers using Argonaut" in {
     assert(decodeInts(printIntsA) === Some(ints))
   }
@@ -33,6 +37,10 @@ class PrintingBenchmarkSpec extends FlatSpec {
 
   it should "correctly print case classes using Circe" in {
     assert(decodeFoos(printFoosC) === Some(foos))
+  }
+
+  it should "correctly print case classes using Circe with Jackson" in {
+    assert(decodeFoos(printFoosCJ) === Some(foos))
   }
 
   it should "correctly print case classes using Argonaut" in {

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val circe = project.in(file("."))
     parse, parseJS,
     tests, testsJS,
     jawn,
+    jackson,
     async,
     benchmark
   )
@@ -186,7 +187,7 @@ lazy val testsBase = crossProject.in(file("tests"))
   )
   .jvmSettings(fork := true)
   .jsSettings(commonJsSettings: _*)
-  .jvmConfigure(_.copy(id = "tests").dependsOn(jawn, async))
+  .jvmConfigure(_.copy(id = "tests").dependsOn(jawn, jackson, async))
   .jsConfigure(_.copy(id = "testsJS"))
   .dependsOn(coreBase, genericBase, refinedBase, parseBase)
 
@@ -201,6 +202,20 @@ lazy val jawn = project
   .settings(allSettings)
   .settings(
     libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.3"
+  )
+  .dependsOn(core)
+
+lazy val jackson = project
+  .settings(
+    description := "circe jackson",
+    moduleName := "circe-jackson"
+  )
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.6.3",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.3"
+    )
   )
   .dependsOn(core)
 
@@ -232,7 +247,7 @@ lazy val benchmark = project
     )
   )
   .enablePlugins(JmhPlugin)
-  .dependsOn(core, generic, jawn)
+  .dependsOn(core, generic, jawn, jackson)
 
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -1,0 +1,110 @@
+package io.circe.jackson
+
+import cats.data.Xor
+import com.fasterxml.jackson.core.{ JsonParser, JsonTokenId }
+import com.fasterxml.jackson.databind.`type`.TypeFactory
+import com.fasterxml.jackson.databind.{ DeserializationContext, JsonDeserializer }
+import io.circe.{ Json, JsonBigDecimal, JsonObject }
+import java.util.ArrayList
+import scala.annotation.{ switch, tailrec }
+
+private[jackson] sealed trait DeserializerContext {
+  def addValue(value: Json): DeserializerContext
+}
+
+private[jackson] case class ReadingList(content: ArrayList[Json]) extends DeserializerContext {
+  def addValue(value: Json): DeserializerContext = ReadingList { content.add(value); content }
+}
+
+private[jackson] case class KeyRead(content: ArrayList[(String, Json)], fieldName: String)
+  extends DeserializerContext {
+  def addValue(value: Json): DeserializerContext = ReadingMap {
+    content.add(fieldName -> value)
+    content
+  }
+}
+
+private[jackson] case class ReadingMap(content: ArrayList[(String, Json)])
+  extends DeserializerContext {
+  def setField(fieldName: String): DeserializerContext = KeyRead(content, fieldName)
+  def addValue(value: Json): DeserializerContext =
+    throw new Exception("Cannot add a value on an object without a key, malformed JSON object!")
+}
+
+private[jackson] class CirceJsonDeserializer(factory: TypeFactory, klass: Class[_])
+  extends JsonDeserializer[Object] {
+  override def isCachable: Boolean = true
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): Json = {
+    val value = deserialize(jp, ctxt, List())
+    if (!klass.isAssignableFrom(value.getClass)) throw ctxt.mappingException(klass)
+
+    value
+  }
+
+  @tailrec
+  final def deserialize(
+    jp: JsonParser,
+    ctxt: DeserializationContext,
+    parserContext: List[DeserializerContext]
+  ): Json = {
+    if (jp.getCurrentToken == null) jp.nextToken()
+
+    val (maybeValue, nextContext) = (jp.getCurrentToken.id(): @switch) match {
+      case JsonTokenId.ID_NUMBER_INT | JsonTokenId.ID_NUMBER_FLOAT =>
+        (Some(Json.JNumber(JsonBigDecimal(new BigDecimal(jp.getDecimalValue)))), parserContext)
+
+      case JsonTokenId.ID_STRING => (Some(Json.JString(jp.getText)), parserContext)
+      case JsonTokenId.ID_TRUE => (Some(Json.JBoolean(true)), parserContext)
+      case JsonTokenId.ID_FALSE => (Some(Json.JBoolean(false)), parserContext)
+      case JsonTokenId.ID_NULL => (Some(Json.JNull), parserContext)
+      case JsonTokenId.ID_START_ARRAY => (None, ReadingList(new ArrayList) +: parserContext)
+
+      case JsonTokenId.ID_END_ARRAY => parserContext match {
+        case ReadingList(content) :: stack =>
+          (Some(Json.JArray(content.toArray(new Array[Json](content.size)))), stack)
+        case _ => throw new RuntimeException("We weren't reading a list, something went wrong")
+      }
+
+      case JsonTokenId.ID_START_OBJECT => (None, ReadingMap(new ArrayList) +: parserContext)
+
+      case JsonTokenId.ID_FIELD_NAME => parserContext match {
+        case (c: ReadingMap) :: stack => (None, c.setField(jp.getCurrentName) +: stack)
+        case _ => throw new RuntimeException("We weren't reading an object, something went wrong")
+      }
+
+      case JsonTokenId.ID_END_OBJECT => parserContext match {
+        case ReadingMap(content) :: stack => (
+          Some(
+            Json.JObject(
+              JsonObject.fromIndexedSeq(content.toArray(new Array[(String, Json)](content.size)))
+            )
+          ),
+          stack
+        )
+        case _ => throw new RuntimeException("We weren't reading an object, something went wrong")
+      }
+
+      case JsonTokenId.ID_NOT_AVAILABLE =>
+        throw new RuntimeException("We weren't reading an object, something went wrong")
+
+      case JsonTokenId.ID_EMBEDDED_OBJECT =>
+        throw new RuntimeException("We weren't reading an object, something went wrong")
+    }
+
+    jp.nextToken()
+
+    maybeValue match {
+      case Some(v) if nextContext.isEmpty => v
+      case maybeValue =>
+        val toPass = maybeValue.map { v =>
+          val previous :: stack = nextContext
+          (previous.addValue(v)) +: stack
+        }.getOrElse(nextContext)
+
+        deserialize(jp, ctxt, toPass)
+    }
+  }
+
+  override def getNullValue = Json.JNull
+}

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
@@ -1,0 +1,52 @@
+package io.circe.jackson
+
+import cats.data.Xor
+import com.fasterxml.jackson.core.Version
+import com.fasterxml.jackson.databind.Module.SetupContext
+import com.fasterxml.jackson.databind.deser.Deserializers
+import com.fasterxml.jackson.databind.{
+  BeanDescription,
+  DeserializationConfig,
+  JavaType,
+  JsonDeserializer,
+  JsonSerializer,
+  SerializationConfig
+}
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.Serializers
+import io.circe.Json
+
+object CirceJsonModule extends SimpleModule("CirceJson", Version.unknownVersion()) {
+  override def setupModule(context: SetupContext): Unit = {
+    context.addDeserializers(
+      new Deserializers.Base {
+        override def findBeanDeserializer(
+          javaType: JavaType,
+          config: DeserializationConfig,
+          beanDesc: BeanDescription
+        ) = {
+          val klass = javaType.getRawClass
+          if (classOf[Json].isAssignableFrom(klass) || klass == Json.JNull.getClass) {
+            new CirceJsonDeserializer(config.getTypeFactory, klass)
+          } else null
+        }
+      }
+    )
+
+    context.addSerializers(
+      new Serializers.Base {
+        override def findSerializer(
+          config: SerializationConfig,
+          javaType: JavaType,
+          beanDesc: BeanDescription
+        ) = {
+          val ser: Object = if (classOf[Json].isAssignableFrom(beanDesc.getBeanClass)) {
+            CirceJsonSerializer
+          } else null
+
+          ser.asInstanceOf[JsonSerializer[Object]]
+        }
+      }
+    )
+  }
+}

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonSerializer.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonSerializer.scala
@@ -1,0 +1,46 @@
+package io.circe.jackson
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.{ JsonSerializer, SerializerProvider }
+import io.circe.{ Json, JsonBigDecimal, JsonDecimal, JsonDouble, JsonLong }
+
+private[jackson] object CirceJsonSerializer extends JsonSerializer[Json] {
+  import java.math.{ BigDecimal => JBigDecimal, BigInteger }
+  import com.fasterxml.jackson.databind.node.{ BigIntegerNode, DecimalNode }
+
+  override def serialize(
+    value: Json,
+    json: JsonGenerator,
+    provider: SerializerProvider
+  ): Unit = value match {
+    case Json.JNumber(v) => v match {
+      case JsonLong(x) => json.writeNumber(x)
+      case JsonDouble(x) => json.writeNumber(x)
+      case JsonDecimal(x) => json.writeString(x)
+      case JsonBigDecimal(x) =>
+        // Workaround #3784: Same behaviour as if JsonGenerator were
+        // configured with WRITE_BIGDECIMAL_AS_PLAIN, but forced as this
+        // configuration is ignored when called from ObjectMapper.valueToTree
+        val raw = x.bigDecimal.stripTrailingZeros.toPlainString
+
+        if (raw contains ".") json.writeTree(new DecimalNode(new JBigDecimal(raw)))
+          else json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+    }
+    case Json.JString(v) => json.writeString(v)
+    case Json.JBoolean(v) => json.writeBoolean(v)
+    case Json.JArray(elements) => {
+      json.writeStartArray()
+      elements.foreach { t => serialize(t, json, provider) }
+      json.writeEndArray()
+    }
+    case Json.JObject(values) => {
+      json.writeStartObject()
+      values.toList.foreach { t =>
+        json.writeFieldName(t._1)
+        serialize(t._2, json, provider)
+      }
+      json.writeEndObject()
+    }
+    case Json.JNull => json.writeNull()
+  }
+}

--- a/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
+++ b/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
@@ -1,0 +1,26 @@
+package io.circe.jackson
+
+import cats.data.Xor
+import io.circe.{ Json, ParsingFailure, Parser }
+import java.io.File
+import scala.util.control.NonFatal
+
+trait JacksonParser extends Parser { this: WithJacksonMapper =>
+  def parse(input: String): Xor[ParsingFailure, Json] = try {
+    Xor.right(mapper.readValue(jsonStringParser(input), classOf[Json]))
+  } catch {
+    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+  }
+
+  def parseFile(file: File): Xor[ParsingFailure, Json] = try {
+    Xor.right(mapper.readValue(jsonFileParser(file), classOf[Json]))
+  } catch {
+    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+  }
+
+  def parseByteArray(bytes: Array[Byte]): Xor[ParsingFailure, Json] = try {
+    Xor.right(mapper.readValue(jsonBytesParser(bytes), classOf[Json]))
+  } catch {
+    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+  }
+}

--- a/jackson/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
+++ b/jackson/src/main/scala/io/circe/jackson/WithJacksonMapper.scala
@@ -1,0 +1,15 @@
+package io.circe.jackson
+
+import com.fasterxml.jackson.core.{ JsonFactory, JsonParser }
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.{ File, StringWriter }
+
+class WithJacksonMapper {
+  protected val mapper: ObjectMapper = (new ObjectMapper).registerModule(CirceJsonModule)
+  private[this] val jsonFactory: JsonFactory = new JsonFactory(mapper)
+
+  protected def jsonStringParser(input: String): JsonParser = jsonFactory.createParser(input)
+  protected def jsonFileParser(file: File): JsonParser = jsonFactory.createParser(file)
+  protected def jsonBytesParser(bytes: Array[Byte]): JsonParser = jsonFactory.createParser(bytes)
+  protected def stringJsonGenerator(out: StringWriter) = jsonFactory.createGenerator(out)
+}

--- a/jackson/src/main/scala/io/circe/jackson/package.scala
+++ b/jackson/src/main/scala/io/circe/jackson/package.scala
@@ -1,0 +1,22 @@
+package io.circe
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.ObjectWriter
+
+/**
+ * Support for Jackson-powered parsing and printing for circe.
+ *
+ * The implementation is ported with minimal changes from Play JSON.
+ */
+package object jackson extends WithJacksonMapper with JacksonParser {
+  def jacksonPrint(json: Json): String = {
+    val sw = new java.io.StringWriter
+    val gen = stringJsonGenerator(sw).setPrettyPrinter(
+      new DefaultPrettyPrinter()
+    )
+    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter()
+    writer.writeValue(gen, json)
+    sw.flush()
+    sw.getBuffer.toString
+  }
+}

--- a/jackson/src/main/scala/io/circe/jackson/syntax/package.scala
+++ b/jackson/src/main/scala/io/circe/jackson/syntax/package.scala
@@ -1,0 +1,12 @@
+package io.circe.jackson
+
+import io.circe.Json
+
+/**
+ * This package provides syntax for Jackson printing via enrichment classes.
+ */
+package object syntax {
+  implicit class JacksonPrintingOps[A](val json: Json) extends AnyVal {
+    def jacksonPrint: String = io.circe.jackson.jacksonPrint(json)
+  }
+}

--- a/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
+++ b/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
@@ -1,0 +1,36 @@
+package io.circe.jackson
+
+import cats.data.{ NonEmptyList, Validated, Xor }
+import io.circe.tests.{ CirceSuite, ParserTests }
+import io.circe.tests.examples.glossary
+import java.io.File
+import org.scalacheck.Prop.forAll
+import scala.io.Source
+
+class JacksonParserSuite extends CirceSuite {
+  checkAll("Parser", ParserTests(`package`).parser)
+
+  test("Parsing should fail on invalid input") {
+    check {
+      forAll { (s: String) =>
+        parse(s"Not JSON $s").isLeft
+      }
+    }
+  }
+
+  test("parseFile") {
+    val url = getClass.getResource("/io/circe/tests/examples/glossary.json")
+    val file = new File(url.toURI)
+
+    assert(parseFile(file) === Xor.right(glossary))
+  }
+
+  test("parseByteArray") {
+    val stream = getClass.getResourceAsStream("/io/circe/tests/examples/glossary.json")
+    val source = Source.fromInputStream(stream)
+    val bytes = source.map(_.toByte).toArray
+    source.close()
+
+    assert(parseByteArray(bytes) === Xor.right(glossary))
+  }
+}

--- a/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
+++ b/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
@@ -1,0 +1,13 @@
+package io.circe.jackson
+
+import cats.data.Xor
+import io.circe.Json
+import io.circe.tests.CirceSuite
+
+class JacksonPrintingSuite extends CirceSuite {
+  test("Printing should result in round-trippable output") {
+    check { (json: Json) =>
+      io.circe.jawn.parse(jacksonPrint(json)) === Xor.right(json)
+    }
+  }
+}


### PR DESCRIPTION
After yesterday's [printing debacle](https://github.com/travisbrown/circe/pull/110) I was curious what using Jackson for printing would look like, and the result is this new circe-jackson subproject. The implementation is ported from [Play JSON](https://www.playframework.com/documentation/2.5.x/ScalaJson), and the package provides both parsing (using the `io.circe.Parser` interface) and printing (via a `jacksonPrint` method that's optionally available as a syntactic extension on `Json`). There's also a `CirceJsonModule` Jackson module for people who want more flexibility in using Jackson and circe together.

The printing performance is quite a bit better than the default printers circe provides, and the parsing is quite a bit worse than what you get with circe-jawn:

```
Benchmark                       Mode  Cnt      Score     Error  Units

PrintingBenchmark.printFoosA   thrpt   40   2608.639 ±  72.145  ops/s
PrintingBenchmark.printFoosC   thrpt   40   3551.012 ±  37.700  ops/s
PrintingBenchmark.printFoosCJ  thrpt   40   4704.822 ±  43.596  ops/s

PrintingBenchmark.printIntsA   thrpt   40  14633.012 ± 334.852  ops/s
PrintingBenchmark.printIntsC   thrpt   40  21978.035 ± 218.315  ops/s
PrintingBenchmark.printIntsCJ  thrpt   40  54072.451 ± 593.552  ops/s

ParsingBenchmark.parseFoosA    thrpt   40   2071.026 ±  48.312  ops/s
ParsingBenchmark.parseFoosC    thrpt   40   3154.946 ±  57.986  ops/s
ParsingBenchmark.parseFoosCJ   thrpt   40   2677.252 ±  26.626  ops/s

ParsingBenchmark.parseIntsA    thrpt   40  10591.170 ± 297.476  ops/s
ParsingBenchmark.parseIntsC    thrpt   40  33377.001 ± 312.896  ops/s
ParsingBenchmark.parseIntsCJ   thrpt   40  16761.651 ± 299.564  ops/s
```

`A` stands for Argonaut, `C` for circe, and `CJ` for circe-jackson.

I've included the commits from #110 to make sure the comparison is fair—I'll rebase this PR once that one's merged.