### PR TITLE
Use the cats 0.4.0 snapshot (do not merge)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "0.3.0"
+lazy val catsVersion = "0.4.0-SNAPSHOT"
 lazy val shapelessVersion = "2.3.0-SNAPSHOT"
 lazy val refinedVersion = "0.3.2"
 


### PR DESCRIPTION
I'm opening this PR so that any issues turn up early, but I don't think we'll end up merging it unless it looks like cats 0.4.0 is going to be out before Shapeless 2.3.0.