### PR TITLE
Optimize cursor representations (making history lazy, etc.)

### DIFF
--- a/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -27,7 +27,9 @@ abstract class Cursor extends CursorOperations {
   /**
    * Create an [[HCursor]] for this cursor in order to track history.
    */
-  def hcursor: HCursor = HCursor(this, Nil)
+  def hcursor: HCursor = new HCursor(this) {
+    def history: List[HistoryOp] = Nil
+  }
 }
 
 object Cursor {

--- a/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -15,7 +15,9 @@ import scala.annotation.tailrec
  * @see [[GenericCursor]]
  * @author Travis Brown
  */
-case class HCursor(cursor: Cursor, history: List[HistoryOp]) extends HCursorOperations {
+abstract class HCursor private[circe](val cursor: Cursor) extends HCursorOperations {
+  def history: List[HistoryOp]
+
   /**
    * Create an [[ACursor]] for this cursor.
    */
@@ -62,7 +64,6 @@ case class HCursor(cursor: Cursor, history: List[HistoryOp]) extends HCursorOper
 
 object HCursor {
   implicit val eqHCursor: Eq[HCursor] = Eq.instance {
-    case (HCursor(c1, h1), HCursor(c2, h2)) =>
-      Eq[Cursor].eqv(c1, c2) && h1 == h2
+    case (hc1, hc2) => Eq[Cursor].eqv(hc1.cursor, hc2.cursor) && (hc1.history == hc2.history)
   }
 }


### PR DESCRIPTION
There are only minor changes to the API here (e.g. no more `HCursor.apply`), but `HCursor` and `ACursor` now use slightly different representations, and the history provided by `HCursor` is lazy—the list of `HistoryOp` items won't be created unless you ask for it.

In general you only need the history in the case of a decoding failure, so computing it only on demand seems perfectly reasonable.

This has a pretty huge impact on performance:

Current master:
```
DecodingBenchmark.decodeFoosC      thrpt   80    2175.136 ±   12.538  ops/s
DecodingBenchmark.decodeIntsC      thrpt   80   11732.675 ±  417.534  ops/s
```
And this PR:

```
DecodingBenchmark.decodeFoosC      thrpt   80    2328.876 ±   27.059  ops/s
DecodingBenchmark.decodeIntsC      thrpt   80   13882.966 ±  201.895  ops/s
```

Including allocation rates. For current master:

```
DecodingBenchmark.decodeFoosC:gc.alloc.rate.norm  thrpt   10  1935616.225 ±      0.018    B/op
DecodingBenchmark.decodeIntsC:gc.alloc.rate.norm  thrpt   10   366634.179 ±     10.229    B/op
```

And this PR:

```
DecodingBenchmark.decodeFoosC:gc.alloc.rate.norm  thrpt   10  1712028.188 ±   1306.782    B/op
DecodingBenchmark.decodeIntsC:gc.alloc.rate.norm  thrpt   10   338540.037 ±  19142.773    B/op
```