### PR TITLE
Simplify error types and implementations

### DIFF
--- a/core/shared/src/main/scala/io/circe/Error.scala
+++ b/core/shared/src/main/scala/io/circe/Error.scala
@@ -3,7 +3,7 @@ package io.circe
 import algebra.Eq
 import cats.std.list._
 
-trait Error extends Exception
+sealed trait Error extends Exception
 
 case class ParsingFailure(message: String, underlying: Throwable) extends Error {
   override def getMessage: String = message
@@ -31,10 +31,9 @@ object DecodingFailure {
 
 object Error {
   implicit val eqError: Eq[Error] = Eq.instance {
-    case (ParsingFailure(m1, u1), ParsingFailure(m2, u2)) =>
-      m1 == m2 && u1 == u2
-    case (DecodingFailure(m1, h1), DecodingFailure(m2, h2)) =>
-      m1 == m2 && Eq[List[HistoryOp]].eqv(h1, h2)
+    case (pf1: ParsingFailure, pf2: ParsingFailure) => ParsingFailure.eqParsingFailure.eqv(pf1, pf2)
+    case (df1: DecodingFailure, df2: DecodingFailure) =>
+      DecodingFailure.eqDecodingFailure.eqv(df1, df2)
     case (_, _) => false
   }
 }


### PR DESCRIPTION
I don't think the sealedness should be controversial, and the other change just removes some repetition.