### PR TITLE
Add convenience methods for decoders

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -116,7 +116,7 @@ trait Decoder[A] extends Serializable { self =>
   /**
    * Create a new decoder that performs some operation on the incoming JSON before decoding.
    */
-  final def after(f: HCursor => ACursor): Decoder[A] = Decoder.instance(c => self.tryDecode(f(c)))
+  final def prepare(f: HCursor => ACursor): Decoder[A] = Decoder.instance(c => self.tryDecode(f(c)))
 
   /**
    * Create a new decoder that performs some operation on the result if this one succeeds.

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -1,0 +1,46 @@
+package io.circe
+
+import cats.data.Xor
+import io.circe.syntax._
+import io.circe.tests.CirceSuite
+
+class DecoderSuite extends CirceSuite {
+  test("after with identity") {
+    check { (i: Int) =>
+      Decoder[Int].after(ACursor.ok).decodeJson(i.asJson) === Xor.right(i)
+    }
+  }
+
+  test("after with downField") {
+    check { (i: Int, k: String, m: Map[String, Int]) =>
+      Decoder[Int].after(_.downField(k)).decodeJson(m.updated(k, i).asJson) === Xor.right(i)
+    }
+  }
+
+  test("emap with identity") {
+    check { (i: Int) =>
+      Decoder[Int].emap(Xor.right).decodeJson(i.asJson) === Xor.right(i)
+    }
+  }
+
+  test("emap with increment") {
+    check { (i: Int) =>
+      Decoder[Int].emap(v => Xor.right(v + 1)).decodeJson(i.asJson) === Xor.right(i + 1)
+    }
+  }
+
+  test("emap with possibly failing operation") {
+    check { (i: Int) =>
+      val decoder = Decoder[Int].emap(v => if (v % 2 == 0) Xor.right(v) else Xor.left("Odd"))
+      val expected = if (i % 2 == 0) Xor.right(i) else Xor.left(DecodingFailure("Odd", Nil))
+
+      decoder.decodeJson(i.asJson) === expected
+    }
+  }
+
+  test("failWith") {
+    check { (json: Json) =>
+      Decoder.failWith[Int]("Bad").decodeJson(json) === Xor.left(DecodingFailure("Bad", Nil))
+    }
+  }
+}

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -5,15 +5,15 @@ import io.circe.syntax._
 import io.circe.tests.CirceSuite
 
 class DecoderSuite extends CirceSuite {
-  test("after with identity") {
+  test("prepare with identity") {
     check { (i: Int) =>
-      Decoder[Int].after(ACursor.ok).decodeJson(i.asJson) === Xor.right(i)
+      Decoder[Int].prepare(ACursor.ok).decodeJson(i.asJson) === Xor.right(i)
     }
   }
 
-  test("after with downField") {
+  test("prepare with downField") {
     check { (i: Int, k: String, m: Map[String, Int]) =>
-      Decoder[Int].after(_.downField(k)).decodeJson(m.updated(k, i).asJson) === Xor.right(i)
+      Decoder[Int].prepare(_.downField(k)).decodeJson(m.updated(k, i).asJson) === Xor.right(i)
     }
   }
 


### PR DESCRIPTION
`before` and `after` here are kind of like `contramap` and `andThen` for kleisli arrows, but I didn't want to use those names since these aren't literally composition.

I've been meaning to add these helper methods for a while. The general motivation is to allow definitions like this (from @etaty on [Gitter](https://gitter.im/travisbrown/circe?at=5654a74492aa9746647b61e2)):

```scala
val df = DateTimeFormat.forPattern("YYYY-MM-dd'T'HH:mm:ssZ")
val decoderDateTime: Decoder[DateTime] = Decoder.instance { cursor =>
  cursor.as[String].flatMap { s =>
    Xor.catchOnly[IllegalArgumentException] {
      DateTime.parse(s, df)
    }.leftMap(e => DecodingFailure(e.getMessage, cursor.history))
  }
}
```

Like this:

```scala
val df = DateTimeFormat.forPattern("YYYY-MM-dd'T'HH:mm:ssZ")
val decoderDateTime: Decoder[DateTime] = Decoder[String].after(s =>
  Xor.catchOnly[IllegalArgumentException](DateTime.parse(s, df)).leftMap(_.getMessage)
)
```