### PR TITLE
JsonNumber-to-Long conversion shouldn't throw exceptions

### DIFF
--- a/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -188,9 +188,11 @@ private[circe] final case class JsonDecimal(value: String) extends JsonNumber {
   lazy val toDouble: Double = value.toDouble
   override def toString: String = value
 
-  def toLong: Option[Long] = {
+  def toLong: Option[Long] = try {
     val asBigDecimal: BigDecimal = toBigDecimal
     if (asBigDecimal.isValidLong) Some(asBigDecimal.toLong) else None
+  } catch {
+    case _: NumberFormatException => None
   }
 
   def truncateToLong: Long = {


### PR DESCRIPTION
This is a fix for one small part of #124: it's consistent with the fourth item in my proposal there, although if we take the rest of those steps the implementation will look a little different. I think this change is worth having on its own, though, in the shorter term.