### PR TITLE
Add non-compilation tests for bad instances

### DIFF
--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -13,17 +13,4 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * sealed trait hierarchies, etc.
  */
 @reexports[DerivedDecoder, DerivedObjectEncoder]
-object auto {
-  /**
-   * Blocks derivation until Shapeless #453 is fixed.
-   */
-  implicit def decodeObject0: Decoder[Object] = sys.error("No Decoder[Object]")
-  implicit def decodeObject1: Decoder[Object] = sys.error("No Decoder[Object]")
-  implicit def decodeAnyRef0: Decoder[AnyRef] = sys.error("No Decoder[AnyRef]")
-  implicit def decodeAnyRef1: Decoder[AnyRef] = sys.error("No Decoder[AnyRef]")
-
-  implicit def encodeObject0: Encoder[Object] = sys.error("No Encoder[Object]")
-  implicit def encodeObject1: Encoder[Object] = sys.error("No Encoder[Object]")
-  implicit def encodeAnyRef0: Encoder[AnyRef] = sys.error("No Encoder[AnyRef]")
-  implicit def encodeAnyRef1: Encoder[AnyRef] = sys.error("No Encoder[AnyRef]")
-}
+object auto

--- a/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -9,6 +9,7 @@ import io.circe.tests.examples._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Prop.forAll
 import shapeless.{ CNil, Witness }, shapeless.labelled.{ FieldType, field }
+import shapeless.test.illTyped
 
 class AutoDerivedSuite extends CirceSuite {
   final case class InnerCaseClassExample(a: String, b: String, c: String, d: String)
@@ -154,5 +155,15 @@ class AutoDerivedSuite extends CirceSuite {
 
   test("Encoding with Encoder[CNil] should throw an exception") {
     intercept[RuntimeException](Encoder[CNil].apply(null: CNil))
+  }
+
+  test("Generic instances should not be derived for Object") {
+    illTyped("Decoder[Object]")
+    illTyped("Encoder[Object]")
+  }
+
+  test("Generic instances should not be derived for AnyRef") {
+    illTyped("Decoder[AnyRef]")
+    illTyped("Encoder[AnyRef]")
   }
 }


### PR DESCRIPTION
Now that [this Shapeless bug](https://github.com/milessabin/shapeless/issues/453) is fixed in the 2.3.0 snapshot, we can remove our workaround and add non-compilation tests. Fixes #57.