### PR TITLE
Remove OpenJDK 7 from the Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ scala:
   - 2.11.7
 
 jdk:
-  - openjdk7
   - oraclejdk7
   - oraclejdk8
 


### PR DESCRIPTION
Some context (from a question I just asked [on Gitter](https://gitter.im/travisbrown/circe?at=567177042f6e4bb04ea72cd3)):

> How do people feel about removing OpenJDK 7 from the Travis CI build matrix? There are new spurious failures happening that look similar to a Travis CI issue that I reported in a completely different context almost a year ago: travis-ci/travis-ci#3120 https://travis-ci.org/travisbrown/circe/builds/97200247
> I've never personally seen a real failure on OpenJDK 7 that didn't also turn up on Oracle's 7, and I'm not sure the possibility is worth the fussiness it takes to keep OpenJDK 7 happy on Travis CI.