### PR TITLE
Fix broken hashCode for Json values

### DIFF
--- a/core/shared/src/main/scala/io/circe/Json.scala
+++ b/core/shared/src/main/scala/io/circe/Json.scala
@@ -135,11 +135,6 @@ sealed abstract class Json extends Product with Serializable {
     case that: Json => Json.eqJson.eqv(this, that)
     case _ => false
   }
-
-  /**
-   * Hashing that is consistent with our universal equality.
-   */
-  override def hashCode: Int = super.hashCode
 }
 
 object Json {


### PR DESCRIPTION
This is a very old bug (around since #16) that finally started causing problems for @pvillega in #141.

Removing the `hashCode` definition means each case class will have its own generated `hashCode` that will be consistent with the `equals` on `Json`.

This seems to fix the issue, but I really wish we had tests in place for this kind of thing.