### PR TITLE
Fix error in refined ScalaDoc example

### DIFF
--- a/refined/shared/src/main/scala/io/circe/refined.scala
+++ b/refined/shared/src/main/scala/io/circe/refined.scala
@@ -15,7 +15,7 @@ import eu.timepit.refined.api.{ RefType, Validate }
  *    i: Int Refined Positive
  *  )
  *
- *  Obj(refineV(4)).asJson.nospaces == """{"i":4}"""
+ *  Obj(refineMV(4)).asJson.nospaces == """{"i":4}"""
  * }}}
  * 
  * @author Alexandre Archambault


### PR DESCRIPTION
`refineV` is a function that returns an `Either[String, Int Refined Positive]` and `refineMV` is a macro that returns an `Int Refined Positive` or fails to compile.