### PR TITLE
Fix Scalastyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,8 @@ lazy val baseSettings = Seq(
       case Some((2, 10)) => false
       case _ => true
     }
-  )
+  ),
+  (scalastyleSources in Compile) <++= unmanagedSourceDirectories in Compile
 )
 
 lazy val allSettings = buildSettings ++ baseSettings ++ publishSettings

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -1,11 +1,10 @@
 package io.circe
 
-import java.util.UUID
-
-import cats.Foldable
 import cats.data.{ NonEmptyList, Validated, Xor }
 import cats.functor.Contravariant
 import cats.std.list._
+import cats.Foldable
+import java.util.UUID
 import scala.collection.generic.IsTraversableOnce
 import scala.collection.mutable.ArrayBuffer
 

--- a/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -3,7 +3,6 @@ package io.circe
 import algebra.Eq
 import cats.data.{ NonEmptyList, Validated, Xor }
 import io.circe.cursor.HCursorOperations
-
 import scala.annotation.tailrec
 
 /**

--- a/core/shared/src/main/scala/io/circe/Json.scala
+++ b/core/shared/src/main/scala/io/circe/Json.scala
@@ -135,6 +135,11 @@ sealed abstract class Json extends Product with Serializable {
     case that: Json => Json.eqJson.eqv(this, that)
     case _ => false
   }
+
+  /**
+   * Use implementations provided by case classes.
+   */
+  override def hashCode(): Int
 }
 
 object Json {

--- a/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
@@ -1,6 +1,6 @@
 package io.circe.cursor
 
-import cats.{ Id, Functor }
+import cats.{ Functor, Id }
 import cats.data.Xor
 import io.circe.{ ACursor, Cursor, Decoder, DecodingFailure, GenericCursor, HistoryOp, Json }
 import scala.annotation.tailrec

--- a/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
@@ -1,6 +1,6 @@
 package io.circe.cursor
 
-import cats.{ Id, Functor }
+import cats.{ Functor, Id }
 import cats.data.Xor
 import io.circe._
 

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -37,7 +37,7 @@ object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedD
         headJson.as(decodeHead.value).map(h => Inl(field(h)))
       }
   }
-  
+
   implicit def decodeLabelledHList[K <: Symbol, H, T <: HList](implicit
     key: Witness.Aux[K],
     decodeHead: Lazy[Decoder[H]],

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -14,7 +14,7 @@ object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
 
   implicit val encodeCNil: DerivedObjectEncoder[CNil] =
     new DerivedObjectEncoder[CNil] {
-      def encodeObject(a: CNil): JsonObject = 
+      def encodeObject(a: CNil): JsonObject =
         sys.error("No JSON representation of CNil (this shouldn't happen)")
     }
 

--- a/generic/shared/src/main/scala/io/circe/generic/util/PatchWithOptions.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/util/PatchWithOptions.scala
@@ -1,7 +1,7 @@
 package io.circe.generic.util
 
 import shapeless._
-import shapeless.labelled.{ FieldType, field }
+import shapeless.labelled.{ field, FieldType }
 
 trait PatchWithOptions[R <: HList] {
   type Out <: HList

--- a/jackson/src/main/scala/io/circe/jackson/package.scala
+++ b/jackson/src/main/scala/io/circe/jackson/package.scala
@@ -14,7 +14,7 @@ package object jackson extends WithJacksonMapper with JacksonParser {
     val gen = stringJsonGenerator(sw).setPrettyPrinter(
       new DefaultPrettyPrinter()
     )
-    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter()
+    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter[ObjectWriter]()
     writer.writeValue(gen, json)
     sw.flush()
     sw.getBuffer.toString

--- a/refined/shared/src/main/scala/io/circe/refined.scala
+++ b/refined/shared/src/main/scala/io/circe/refined.scala
@@ -17,7 +17,7 @@ import eu.timepit.refined.api.{ RefType, Validate }
  *
  *  Obj(refineMV(4)).asJson.nospaces == """{"i":4}"""
  * }}}
- * 
+ *
  * @author Alexandre Archambault
  */
 object refined {

--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -1,8 +1,8 @@
 package io.circe.tests
 
 import cats.data.NonEmptyList
-import io.circe.Json.{ JArray, JNumber, JObject, JString }
 import io.circe.{ Json, JsonBigDecimal, JsonDouble, JsonLong, JsonNumber, JsonObject }
+import io.circe.Json.{ JArray, JNumber, JObject, JString }
 import java.util.UUID
 import org.scalacheck.{ Arbitrary, Gen, Shrink }
 

--- a/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -10,5 +10,6 @@ import org.typelevel.discipline.scalatest.Discipline
  */
 trait CirceSuite extends FunSuite with Matchers with Discipline with AllInstances with AllSyntax
   with ArbitraryInstances with MissingInstances {
-  override def convertToEqualizer[T](left: T): Equalizer[T] = ???
+  override def convertToEqualizer[T](left: T): Equalizer[T] =
+    sys.error("Intentionally ambiguous implicit for Equalizer")
 }

--- a/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
@@ -127,7 +127,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
         j.asArray.fold(j)(a => Json.fromValues(0.asJson :: a))
       )
     )
-    
+
     assert(result.flatMap(top) === Some(j2))
   }
 

--- a/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -1,8 +1,7 @@
 package io.circe.tests
 
-import java.util.UUID
-
 import algebra.Eq
+import java.util.UUID
 import org.scalacheck.Arbitrary
 import shapeless._
 

--- a/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
@@ -4,9 +4,8 @@ import algebra.Eq
 import cats.data.Xor
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Json, ParsingFailure, Parser }
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import io.circe.{ Json, Parser, ParsingFailure }
+import org.scalacheck.{ Arbitrary, Prop }
 import org.typelevel.discipline.Laws
 
 case class ParserLaws(parser: Parser) {

--- a/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/PrinterSuite.scala
@@ -10,7 +10,7 @@ class PrinterSuite(printer: Printer, parser: Parser) extends CirceSuite {
   checkAll("Printing Double", PrinterTests[Double].printer(printer, parser))
   checkAll("Printing Short", PrinterTests[Short].printer(printer, parser))
   checkAll("Printing Int", PrinterTests[Int].printer(printer, parser))
-  // Temporarily disabling because of problems round-tripping in Scala.js. 
+  // Temporarily disabling because of problems round-tripping in Scala.js.
   //checkAll("Printing Long", PrinterTests[Long].printer(printer, parser))
   checkAll("Printing Map", PrinterTests[Map[String, List[Int]]].printer(printer, parser))
 }


### PR DESCRIPTION
As @fthomas points out [here](https://github.com/scalastyle/scalastyle-sbt-plugin/issues/47), Scalastyle isn't currently seeing any of the sources for Scala.js cross-project modules. This commit adds a temporary fix:

```scala
(scalastyleSources in Compile) <++= unmanagedSourceDirectories in Compile
```

Unfortunately doing the same thing for `in Test` doesn't work, but I'm not too worried about test code being checked for now.