### PR TITLE
Add new module with JSON string interpolator and literal instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,13 +70,21 @@ lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Se
     "-groups",
     "-implicits",
     "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
-    "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
-    "-Ymacro-no-expand"
+    "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath
   ),
   git.remoteRepo := "git@github.com:travisbrown/circe.git",
   unidocProjectFilter in (ScalaUnidoc, unidoc) :=
-    inAnyProject --
-      inProjects(async, benchmark, coreJS, literalJS, genericJS, refinedJS, parseJS, tests, testsJS)
+    inAnyProject -- inProjects(
+      async,
+      benchmark,
+      coreJS,
+      literal, literalJS,
+      genericJS,
+      refinedJS,
+      parseJS,
+      tests,
+      testsJS
+    )
 )
 
 lazy val circe = project.in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,10 @@ lazy val literalBase = crossProject.crossType(CrossType.Pure).in(file("literal")
   )
   .settings(allSettings: _*)
   .settings(
-    libraryDependencies += "org.typelevel" %%% "macro-compat" % "1.1.1-SNAPSHOT"
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+      "org.typelevel" %%% "macro-compat" % "1.1.1-SNAPSHOT"
+    )
   )
   .jsSettings(commonJsSettings: _*)
   .jvmConfigure(_.copy(id = "literal"))

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,7 @@ lazy val circe = project.in(file("."))
       """
         |import io.circe._
         |import io.circe.generic.auto._
+        |import io.circe.literal._
         |import io.circe.parse._
         |import io.circe.syntax._
         |import cats.data.Xor
@@ -114,7 +115,7 @@ lazy val circe = project.in(file("."))
     async,
     benchmark
   )
-  .dependsOn(core, generic, parse)
+  .dependsOn(core, generic, literal, parse)
 
 lazy val coreBase = crossProject.in(file("core"))
   .settings(

--- a/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -1,0 +1,360 @@
+package io.circe.literal
+
+import cats.data.Xor
+import io.circe.{ Json, Parser }
+import java.lang.reflect.{ InvocationHandler, Method, Proxy }
+import java.util.UUID
+import macrocompat.bundle
+import scala.reflect.macros.whitebox
+
+@bundle
+class LiteralMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  private[this] abstract class HandlerHelpers(placeHolders: Map[String, Tree])
+    extends InvocationHandler {
+    final def invoke(proxy: Object, method: Method, args: Array[Object]): Object =
+      (args, method.getParameterTypes) match {
+        case (Array(arg), Array(cls)) => invokeWithArg(method.getName, cls, arg)
+        case _ => invokeWithoutArg(method.getName)
+      }
+
+    def invokeWithoutArg: String => Object
+    def invokeWithArg: (String, Class[_], Object) => Object
+
+    def toJsonString(s: String): Tree =
+      placeHolders.getOrElse(s, q"_root_.io.circe.Json.string($s)")
+
+    def asProxy(cls: Class[_]): Object =
+      Proxy.newProxyInstance(getClass.getClassLoader, Array(cls), this)
+  }
+
+  private[this] class SingleContextHandler(placeHolders: Map[String, Tree])
+    extends HandlerHelpers(placeHolders) {
+    var value: Tree = null
+
+    val invokeWithoutArg: String => Object = {
+      case "finish" => value
+      case "isObj" => false: java.lang.Boolean
+    }
+
+    val invokeWithArg: (String, Class[_], Object) => Object = {
+      case ("add", cls, arg: String) if cls == classOf[String] =>
+        value = toJsonString(arg)
+        null
+      case ("add", cls, arg: Tree) =>
+        value = arg
+        null
+    }
+  }
+
+  private[this] class ArrayContextHandler(placeHolders: Map[String, Tree])
+    extends HandlerHelpers(placeHolders) {
+    var values: List[Tree] = Nil
+
+    val invokeWithoutArg: String => Object = {
+      case "finish" => q"_root_.io.circe.Json.array(..$values)"
+      case "isObj" => false: java.lang.Boolean
+    }
+
+    val invokeWithArg: (String, Class[_], Object) => Object = {
+      case ("add", cls, arg: String) if cls == classOf[String] =>
+        values = values :+ toJsonString(arg)
+        null
+      case ("add", cls, arg: Tree) =>
+        values = values :+ arg
+        null
+    }
+  }
+
+  private[this] class ObjectContextHandler(placeHolders: Map[String, Tree])
+    extends HandlerHelpers(placeHolders) {
+    var key: String = null
+    var fields: List[Tree] = Nil
+
+    val invokeWithoutArg: String => Object = {
+      case "finish" => q"_root_.io.circe.Json.obj(..$fields)"
+      case "isObj" => true: java.lang.Boolean
+    }
+
+    val invokeWithArg: (String, Class[_], Object) => Object = {
+      case ("add", cls, arg: String) if cls == classOf[String] =>
+        if (key == null) {
+          key = arg
+        } else {
+          fields = fields :+ q"($key, ${ toJsonString(arg) })"
+          key = null
+        }
+        null
+      case ("add", cls, arg: Tree) =>
+        fields = fields :+ q"($key, $arg)"
+        key = null
+        null
+    }
+  }
+
+  private[this] class TreeFacadeHandler(placeHolders: Map[String, Tree])
+    extends HandlerHelpers(placeHolders) {
+    val invokeWithoutArg: String => Object = {
+      case "jnull" => q"_root_.io.circe.Json.empty"
+      case "jfalse" => q"_root_.io.circe.Json.False"
+      case "jtrue" => q"_root_.io.circe.Json.True"
+      case "singleContext" =>
+        new SingleContextHandler(placeHolders).asProxy(Class.forName("jawn.FContext"))
+      case "arrayContext" =>
+        new ArrayContextHandler(placeHolders).asProxy(Class.forName("jawn.FContext"))
+      case "objectContext" =>
+        new ObjectContextHandler(placeHolders).asProxy(Class.forName("jawn.FContext"))
+    }
+
+    val invokeWithArg: (String, Class[_], Object) => Object = {
+      case ("jnum", cls, arg: String) if cls == classOf[String] => q"""
+        _root_.io.circe.Json.fromJsonNumber(
+          _root_.io.circe.JsonNumber.fromString($arg).get
+        )
+      """
+      case ("jint", cls, arg: String) if cls == classOf[String] => q"""
+        _root_.io.circe.Json.fromJsonNumber(
+          _root_.io.circe.JsonNumber.fromString($arg).get
+        )
+      """
+      case ("jstring", cls, arg: String) if cls == classOf[String] => toJsonString(arg)
+    }
+  }
+
+  final def parse(jsonString: String, placeHolders: Map[String, Tree]): Xor[Throwable, Tree] =
+    Xor.catchNonFatal {
+      val jawnParserClass = Class.forName("jawn.Parser$")
+      val jawnParser = jawnParserClass.getField("MODULE$").get(jawnParserClass)
+      val jawnFacadeClass = Class.forName("jawn.Facade")
+      val parseMethod = jawnParserClass.getMethod("parseUnsafe", classOf[String], jawnFacadeClass)
+
+      parseMethod.invoke(
+        jawnParser,
+        jsonString,
+        new TreeFacadeHandler(placeHolders).asProxy(jawnFacadeClass)
+      ).asInstanceOf[Tree]
+    }
+
+  private[this] final def randomPlaceHolder(): String = UUID.randomUUID().toString
+
+  /**
+   * Using Tree here instead of c.Expr fails to compile on 2.10.
+   */
+  final def jsonStringContext(args: c.Expr[Any]*): c.Expr[Json] = c.prefix.tree match {
+    case Apply(_, Apply(_, parts) :: Nil) =>
+      val stringParts = parts.map {
+        case Literal(Constant(part: String)) => part
+        case _ => c.abort(
+          c.enclosingPosition,
+          "A StringContext part for the json interpolator is not a string"
+        )
+      }
+
+      val encodedArgs = args.map { arg =>
+        val tpe = c.typecheck(arg.tree).tpe
+        val placeHolder = Stream.continually(randomPlaceHolder()).distinct.dropWhile(s =>
+          stringParts.exists(_.contains(s))
+        ).head
+
+        (placeHolder, q"_root_.io.circe.Encoder[$tpe].apply($arg)")
+      }
+
+      val placeHolders = encodedArgs.map(_._1)
+
+      if (stringParts.size != encodedArgs.size + 1) c.abort(
+        c.enclosingPosition,
+        "Invalid arguments for the json interpolator"
+      ) else {
+        val jsonString = stringParts.zip(placeHolders).foldLeft("") {
+          case (acc, (part, placeHolder)) =>
+            val qm = "\""
+
+            s"$acc$part$qm$placeHolder$qm"
+        } + stringParts.last
+
+        c.Expr[Json](
+          parse(jsonString, encodedArgs.toMap).valueOr[Tree] {
+            case _: ClassNotFoundException => c.abort(
+              c.enclosingPosition,
+              "The json interpolator requires jawn to be available at compile time"
+            )
+            case t: Throwable => c.abort(
+              c.enclosingPosition,
+              "Invalid JSON in interpolated string"
+            )
+          }
+        )
+      }
+    case _ => c.abort(c.enclosingPosition, "Invalid use of the json interpolator")
+  }
+
+  final def decodeLiteralStringImpl[S <: String: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: String)) =>
+        val name = s"""String("$lit")"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asString.flatMap[$sType] {
+                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralBooleanImpl[S <: Boolean: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Boolean)) =>
+        val name = s"""Boolean($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asBoolean.flatMap[$sType] {
+                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralDoubleImpl[S <: Double: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Double)) =>
+        val name = s"""Double($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asNumber.map(_.toDouble).flatMap[$sType] {
+                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralFloatImpl[S <: Float: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Float)) =>
+        val name = s"""Float($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asNumber.map(_.toDouble).flatMap[$sType] {
+                case s if s.toFloat == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralLongImpl[S <: Long: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Long)) =>
+        val name = s"""Long($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asNumber.flatMap(_.toLong).flatMap[$sType] {
+                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralIntImpl[S <: Int: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Int)) =>
+        val name = s"""Int($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asNumber.flatMap(_.toInt).flatMap[$sType] {
+                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def decodeLiteralCharImpl[S <: Char: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Char)) =>
+        val name = s"""Char($lit)"""
+
+        q"""
+          _root_.io.circe.Decoder.instance[$sType] { c =>
+            _root_.cats.data.Xor.fromOption(
+              c.focus.asString.flatMap[$sType] {
+                case s if s.length == 1 && s.charAt(0) == $lit =>
+                  _root_.scala.Some[$sType]($lit: $sType)
+                case _ => _root_.scala.None
+              },
+              _root_.io.circe.DecodingFailure($name, c.history)
+            )
+          }
+        """
+    }
+
+  final def encodeLiteralStringImpl[S <: String: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: String)) =>
+        q"_root_.io.circe.Encoder.apply[java.lang.String].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralBooleanImpl[S <: Boolean: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Boolean)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Boolean].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralDoubleImpl[S <: Double: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Double)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Double].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralFloatImpl[S <: Float: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Float)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Float].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralLongImpl[S <: Long: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Long)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Long].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralIntImpl[S <: Int: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Int)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Int].contramap[$sType](identity)"
+    }
+
+  final def encodeLiteralCharImpl[S <: Char: c.WeakTypeTag]: Tree =
+    weakTypeOf[S].dealias match {
+      case sType @ ConstantType(Constant(lit: Char)) =>
+        q"_root_.io.circe.Encoder.apply[scala.Char].contramap[$sType](identity)"
+    }
+}

--- a/literal/src/main/scala/io/circe/literal/package.scala
+++ b/literal/src/main/scala/io/circe/literal/package.scala
@@ -1,0 +1,51 @@
+package io.circe
+
+import scala.language.experimental.macros
+
+package object literal {
+  implicit final class JsonStringContext(sc: StringContext) {
+    final def json(args: Any*): Json = macro LiteralMacros.jsonStringContext
+  }
+
+  implicit final def decodeLiteralString[S <: String]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralStringImpl[S]
+
+  implicit final def decodeLiteralBoolean[S <: Boolean]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralBooleanImpl[S]
+
+  implicit final def decodeLiteralDouble[S <: Double]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralDoubleImpl[S]
+
+  implicit final def decodeLiteralFloat[S <: Float]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralFloatImpl[S]
+
+  implicit final def decodeLiteralLong[S <: Long]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralLongImpl[S]
+
+  implicit final def decodeLiteralInt[S <: Int]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralIntImpl[S]
+
+  implicit final def decodeLiteralChar[S <: Char]: Decoder[S] =
+    macro LiteralMacros.decodeLiteralCharImpl[S]
+
+  implicit final def encodeLiteralString[S <: String]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralStringImpl[S]
+
+  implicit final def encodeLiteralBoolean[S <: Boolean]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralBooleanImpl[S]
+
+  implicit final def encodeLiteralDouble[S <: Double]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralDoubleImpl[S]
+
+  implicit final def encodeLiteralFloat[S <: Float]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralFloatImpl[S]
+
+  implicit final def encodeLiteralLong[S <: Long]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralLongImpl[S]
+
+  implicit final def encodeLiteralInt[S <: Int]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralIntImpl[S]
+
+  implicit final def encodeLiteralChar[S <: Char]: Encoder[S] =
+    macro LiteralMacros.encodeLiteralCharImpl[S]
+}

--- a/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
@@ -49,6 +49,17 @@ class JsonInterpolatorSuite extends CirceSuite {
     assert(parsed === Xor.right(interpolated))
   }
 
+  test("The json interpolator should work with interpolated strings as keys") {
+    val key = "foo"
+
+    val interpolated = json"{ $key: 1 }"
+
+    val parsed = parse("""{ "foo": 1 }""")
+
+    assert(parsed === Xor.right(interpolated))
+  }
+
+
   test("The json interpolator should fail with invalid JSON") {
     illTyped("json\"\"\"1a2b3c\"\"\"")
   }

--- a/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
@@ -1,0 +1,63 @@
+package io.circe.literal
+
+import cats.data.Xor
+import io.circe.Json
+import io.circe.parse.parse
+import io.circe.tests.CirceSuite
+import shapeless.test.illTyped
+
+class JsonInterpolatorSuite extends CirceSuite {
+  test("The json interpolator should work with no interpolated variables") {
+    val interpolated = json"""
+    {
+      "a": [1, 2, 3],
+      "b": { "foo": false },
+      "c": null
+    }
+    """
+
+    val parsed = parse(
+      """
+      {
+        "a": [1, 2, 3],
+        "b": { "foo": false },
+        "c": null
+      }
+      """
+    )
+
+    assert(parsed === Xor.right(interpolated))
+  }
+
+  test("The json interpolator should work with interpolated variables") {
+    val i = 13
+    val m = Map("bar" -> List(1, 2, 3), "baz" -> Nil)
+
+    val interpolated = json"""{ "i": $i, "ms": [$m, $m] }"""
+
+    val parsed = parse("""
+      {
+        "i": 13,
+        "ms": [
+          { "bar": [1, 2, 3], "baz": [] },
+          { "bar": [1, 2, 3], "baz": [] }
+        ]
+      }
+      """
+    )
+
+    assert(parsed === Xor.right(interpolated))
+  }
+
+  test("The json interpolator should fail with invalid JSON") {
+    illTyped("json\"\"\"1a2b3c\"\"\"")
+  }
+
+  test("The json interpolator should fail with unencodable interpolated variables") {
+    trait Foo
+
+    val foo = new Foo {}
+
+    illTyped("json\"$foo\"")
+  }
+}

--- a/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
@@ -1,0 +1,61 @@
+package io.circe.literal
+
+import algebra.Eq
+import cats.data.Xor
+import io.circe.{ Decoder, Encoder }
+import io.circe.tests.CirceSuite
+import shapeless.Witness
+
+class LiteralInstancesSuite extends CirceSuite {
+  def eqSingleton[S <: V with Singleton, V: Eq]: Eq[S] = Eq.by[S, V](identity)
+
+  implicit def eqSingletonString[S <: String with Singleton]: Eq[S] = eqSingleton[S, String]
+  implicit def eqSingletonBoolean[S <: Boolean with Singleton]: Eq[S] = eqSingleton[S, Boolean]
+  implicit def eqSingletonDouble[S <: Double with Singleton]: Eq[S] = eqSingleton[S, Double]
+  implicit def eqSingletonFloat[S <: Float with Singleton]: Eq[S] = eqSingleton[S, Float]
+  implicit def eqSingletonLong[S <: Long with Singleton]: Eq[S] = eqSingleton[S, Long]
+  implicit def eqSingletonInt[S <: Int with Singleton]: Eq[S] = eqSingleton[S, Int]
+  implicit def eqSingletonChar[S <: Char with Singleton]: Eq[S] = eqSingleton[S, Char]
+
+  test("Literal string encoding and decoding") {
+    val w = Witness("foo")
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal boolean encoding and decoding") {
+    val w = Witness(true)
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal double encoding and decoding") {
+    val w = Witness(0.0)
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal float encoding and decoding") {
+    val w = Witness(0.0F)
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal long encoding and decoding") {
+    val w = Witness(0L)
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal int encoding and decoding") {
+    val w = Witness(0)
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+
+  test("Literal char encoding and decoding") {
+    val w = Witness('a')
+
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+  }
+}


### PR DESCRIPTION
This change introduces a new circe-literal module with two new features (which are related primarily by the fact that they have something to do with compile-time literals and that their implementations require macros—the first in any circe module).

## JSON string literals

The first feature is [Rapture](http://rapture.io/)-style JSON string interpolation. There are a couple of important differences from the implementation in Rapture. The first is that no parsing happens at runtime. In Rapture the parts of the interpolated string are validated at compile time, but they are parsed at runtime by a parser that's provided implicitly. In the implementation here, parsing happens at compile-time via a compile-time-only dependency on Jawn, and the interpolated string has no runtime existence.

The primary reason for this difference in approach is that I find it more elegant not to duplicate the parsing across compile-time and runtime. I also don't ever want to require users to have a parser in implicit scope. The approach here may also be marginally faster at runtime, but that wasn't the motivation.

Usage looks like this:

```scala
scala> import io.circe.literal._
import io.circe.literal._

scala> val key = "foo"
key: String = foo

scala> val stuff: Map[String, List[Int]] = Map("a" -> List(1, 2, 3), "b" -> Nil)
stuff: Map[String,List[Int]] = Map(a -> List(1, 2, 3), b -> List())

scala> json"""{ $key: $stuff, "bar": false }"""
res0: io.circe.Json =
{
  "foo" : {
    "a" : [
      1,
      2,
      3
    ],
    "b" : [
    ]
  },
  "bar" : false
}

```

Note that circe-literal does not formally depend on Jawn, but JSON literals will fail to compile if Jawn is not available at compile-time (when the macros are expanded). This approach involves a lot of unpleasant compile-time runtime reflection, but as far as I know it's the best way to make these macros available in Scala.js. If you want to use the interpolator in a Scala.js project, you'll have to add something like the following to your build settings:

```scala
ivyConfigurations += config("compile-time").hide,
unmanagedClasspath in Compile
  ++= update.value.select(configurationFilter("compile-time")),
unmanagedClasspath in Test
  ++= update.value.select(configurationFilter("compile-time"))
```

And then add the following dependency to your Scala.js project:

```scala
libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.3" % "compile-time"
```

See the circe-tests configuration for an example of this annoying nonsense in action.

Non-Scala.js projects with a circe-jawn dependency don't have to worry about any of this.

One other annoying note: I'm running into problems with Unidoc (possibly macro-compat-related), so API doc publishing is not currently available for circe-literal. I'll add an issue for this once this PR is merged.

## Singleton codecs

The second feature is singleton codecs, suggested by @alexarchambault in #100. These encoders and decoders allow you to write the following:

```scala
import io.circe._, io.circe.generic.auto._, io.circe.literal._
import shapeless.Witness

case class Foo(i: Int, s: String, constantString: Witness.`"abc"`.T)

val json = Encoder[Foo].apply(Foo(1, "", "abc"))
```

It's not currently possible to use these in Scala without something like Shapeless's `Witness`, but circe-literal itself doesn't depend on Shapeless.