### PR TITLE
Configuring generic derivation (demonstration; do not merge)

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -10,6 +10,8 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 
 trait Decoder[A] extends Serializable { self =>
+  type Config
+
   /**
    * Decode the given hcursor.
    */
@@ -608,3 +610,9 @@ final object Decoder extends TupleDecoders with LowPriorityDecoders {
 }
 
 @export.imports[Decoder] private[circe] trait LowPriorityDecoders
+
+trait ConfiguredDecoder[C, A] extends Decoder[A] {
+  type Config = C
+}
+
+@export.imports[ConfiguredDecoder] object ConfiguredDecoder

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -14,6 +14,8 @@ import scala.collection.mutable.ArrayBuffer
  * @author Travis Brown
  */
 trait Encoder[A] extends Serializable {
+  type Config
+
   /**
    * Converts a value to JSON.
    */
@@ -53,8 +55,6 @@ trait Encoder[A] extends Serializable {
  * @author Travis Brown
  */
 object Encoder extends TupleEncoders with LowPriorityEncoders {
-  type Config
-
   /**
    * Return an instance for a given type `A`.
    *

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -53,6 +53,8 @@ trait Encoder[A] extends Serializable {
  * @author Travis Brown
  */
 object Encoder extends TupleEncoders with LowPriorityEncoders {
+  type Config
+
   /**
    * Return an instance for a given type `A`.
    *
@@ -252,3 +254,9 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
 }
 
 @export.imports[Encoder] private[circe] trait LowPriorityEncoders
+
+trait ConfiguredEncoder[C, A] extends Encoder[A] {
+  type Config = C
+}
+
+@export.imports[ConfiguredEncoder] object ConfiguredEncoder

--- a/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -33,3 +33,7 @@ object ObjectEncoder extends LowPriorityObjectEncoders {
 }
 
 @export.imports[ObjectEncoder] private[circe] trait LowPriorityObjectEncoders
+
+trait ConfiguredObjectEncoder[C, A] extends ObjectEncoder[A] with ConfiguredEncoder[C, A]
+
+@export.imports[ConfiguredObjectEncoder] object ConfiguredObjectEncoder

--- a/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/core/shared/src/main/scala/io/circe/Parser.scala
@@ -7,4 +7,9 @@ trait Parser extends Serializable {
 
   final def decode[A](input: String)(implicit d: Decoder[A]): Xor[Error, A] =
     parse(input).flatMap(d.decodeJson)
+
+  final def configuredDecode[C, A](input: String)(implicit
+    d: ConfiguredDecoder[C, A]
+  ): Xor[Error, A] =
+    parse(input).flatMap(d.decodeJson)
 }

--- a/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/core/shared/src/main/scala/io/circe/Parser.scala
@@ -8,7 +8,7 @@ trait Parser extends Serializable {
   final def decode[A](input: String)(implicit d: Decoder[A]): Xor[Error, A] =
     parse(input).flatMap(d.decodeJson)
 
-  final def configuredDecode[C, A](input: String)(implicit
+  final def decodeConfigured[A, C](input: String)(implicit
     d: ConfiguredDecoder[C, A]
   ): Xor[Error, A] =
     parse(input).flatMap(d.decodeJson)

--- a/core/shared/src/main/scala/io/circe/syntax/package.scala
+++ b/core/shared/src/main/scala/io/circe/syntax/package.scala
@@ -6,5 +6,7 @@ package io.circe
 package object syntax {
   implicit final class EncoderOps[A](val a: A) extends AnyVal {
     final def asJson(implicit e: Encoder[A]): Json = e(a)
+
+    final def asJsonConfigured[C](implicit e: ConfiguredEncoder[C, A]): Json = e(a)
   }
 }

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -11,10 +11,6 @@ import io.circe.generic.encoding.{ ConfiguredDerivedObjectEncoder, DerivedObject
  * instances for tuples, case classes (if all members have instances), "incomplete" case classes,
  * sealed trait hierarchies, etc.
  */
-@reexports[
-  DerivedDecoder,
-  ConfiguredDerivedDecoder,
-  DerivedObjectEncoder,
-  ConfiguredDerivedObjectEncoder
-]
+@reexports[DerivedDecoder, ConfiguredDerivedDecoder,
+  DerivedObjectEncoder, ConfiguredDerivedObjectEncoder]
 final object auto

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,8 +1,8 @@
 package io.circe.generic
 
 import export.reexports
-import io.circe.generic.decoding.DerivedDecoder
-import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.generic.decoding.{ ConfiguredDerivedDecoder, DerivedDecoder }
+import io.circe.generic.encoding.{ ConfiguredDerivedObjectEncoder, DerivedObjectEncoder }
 
 /**
  * Fully automatic codec derivation.
@@ -11,5 +11,10 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * instances for tuples, case classes (if all members have instances), "incomplete" case classes,
  * sealed trait hierarchies, etc.
  */
-@reexports[DerivedDecoder, DerivedObjectEncoder]
+@reexports[
+  DerivedDecoder,
+  ConfiguredDerivedDecoder,
+  DerivedObjectEncoder,
+  ConfiguredDerivedObjectEncoder
+]
 final object auto

--- a/generic/shared/src/main/scala/io/circe/generic/config.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/config.scala
@@ -2,7 +2,7 @@ package io.circe.generic
 
 object config {
   trait SnakeCaseKeys
-  
+
   final def snakeCase(s: String): String =
     s.replaceAll(
       "([A-Z]+)([A-Z][a-z])",

--- a/generic/shared/src/main/scala/io/circe/generic/config.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/config.scala
@@ -1,0 +1,11 @@
+package io.circe.generic
+
+object config {
+  trait SnakeCaseKeys
+  
+  final def snakeCase(s: String): String =
+    s.replaceAll(
+      "([A-Z]+)([A-Z][a-z])",
+      "$1_$2"
+    ).replaceAll("([a-z\\d])([A-Z])", "$1_$2").toLowerCase
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/ConfiguredDerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/ConfiguredDerivedDecoder.scala
@@ -1,0 +1,110 @@
+package io.circe.generic.decoding
+
+import cats.data.Xor
+import cats.syntax.monoidal._
+import io.circe.{ AccumulatingDecoder, ConfiguredDecoder, Decoder, DecodingFailure, HCursor }
+import io.circe.generic.config.{ SnakeCaseKeys, snakeCase }
+import shapeless._, shapeless.labelled.{ FieldType, field }
+
+trait ConfiguredDerivedDecoder[C, A] extends DerivedDecoder[A] with ConfiguredDecoder[C, A]
+
+@export.exports
+final object ConfiguredDerivedDecoder
+  extends IncompleteDerivedDecoders with MidPriorityConfiguredDerivedDecoders {
+  final implicit def decodeHNil[C]: ConfiguredDerivedDecoder[C, HNil] =
+    new ConfiguredDerivedDecoder[C, HNil] {
+      final def apply(c: HCursor): Decoder.Result[HNil] = Xor.right(HNil)
+    }
+
+  implicit final def decodeCNil[C]: ConfiguredDerivedDecoder[C, CNil] =
+    new ConfiguredDerivedDecoder[C, CNil] {
+      final def apply(c: HCursor): Decoder.Result[CNil] =
+        Xor.left(DecodingFailure("CNil", c.history))
+    }
+
+  implicit final def decodeCoproduct[C, K <: Symbol, H, T <: Coproduct](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[ConfiguredDecoder[C, H]],
+    decodeTail: Lazy[ConfiguredDerivedDecoder[C, T]]
+  ): ConfiguredDerivedDecoder[C, FieldType[K, H] :+: T] =
+    new ConfiguredDerivedDecoder[C, FieldType[K, H] :+: T] {
+      final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
+        c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
+          decodeTail.value(c).map(Inr(_))
+        ) { headJson =>
+          headJson.as(decodeHead.value).map(h => Inl(field(h)))
+        }
+    }
+
+  implicit final def decodeLabelledHListSnakeCaseKeys[K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[ConfiguredDecoder[SnakeCaseKeys, H]],
+    decodeTail: Lazy[ConfiguredDerivedDecoder[SnakeCaseKeys, T]]
+  ): ConfiguredDerivedDecoder[SnakeCaseKeys, FieldType[K, H] :: T] = fromDecoder(
+    (decodeHead.value.prepare(_.downField(snakeCase(key.value.name))) |@| decodeTail.value).map(
+      (head, tail) => field[K](head) :: tail
+    )
+  )
+}
+
+private[circe] trait MidPriorityConfiguredDerivedDecoders
+  extends LowPriorityConfiguredDerivedDecoders {
+  implicit final def decodeCoproductDerived[C, K <: Symbol, H, T <: Coproduct](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[ConfiguredDerivedDecoder[C, H]],
+    decodeTail: Lazy[ConfiguredDerivedDecoder[C, T]]
+  ): ConfiguredDerivedDecoder[C, FieldType[K, H] :+: T] =
+    new ConfiguredDerivedDecoder[C, FieldType[K, H] :+: T] {
+      final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
+        c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
+          decodeTail.value(c).map(Inr(_))
+        ) { headJson =>
+          headJson.as(decodeHead.value).map(h => Inl(field(h)))
+        }
+    }
+
+  implicit final def decodeLabelledHListSnakeCaseKeysBase[K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[Decoder[H]],
+    decodeTail: Lazy[ConfiguredDerivedDecoder[SnakeCaseKeys, T]]
+  ): ConfiguredDerivedDecoder[SnakeCaseKeys, FieldType[K, H] :: T] = fromDecoder(
+    (decodeHead.value.prepare(_.downField(snakeCase(key.value.name))) |@| decodeTail.value).map(
+      (head, tail) => field[K](head) :: tail
+    )
+  )
+
+  implicit final def decodeAdt[C, A, R <: Coproduct](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    decode: Lazy[ConfiguredDerivedDecoder[C, R]]
+  ): ConfiguredDerivedDecoder[C, A] = new ConfiguredDerivedDecoder[C, A] {
+    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
+  }
+
+  implicit final def decodeCaseClass[C, A, R <: HList](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    decode: Lazy[ConfiguredDerivedDecoder[C, R]]
+  ): ConfiguredDerivedDecoder[C, A] = new ConfiguredDerivedDecoder[C, A] {
+    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+      decode.value.decodeAccumulating(c).map(gen.from)
+  }
+}
+
+private[circe] trait LowPriorityConfiguredDerivedDecoders {
+  final def fromDecoder[C, A](decode: Decoder[A]): ConfiguredDerivedDecoder[C, A] =
+    new ConfiguredDerivedDecoder[C, A] {
+      final def apply(c: HCursor): Decoder.Result[A] = decode(c)
+      override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+        decode.decodeAccumulating(c)
+    }
+
+  implicit final def decodeLabelledHListUnconfigured[C, K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    decodeHead: Lazy[Decoder[H]],
+    decodeTail: Lazy[ConfiguredDerivedDecoder[C, T]]
+  ): ConfiguredDerivedDecoder[C, FieldType[K, H] :: T] = fromDecoder(
+    (decodeHead.value.prepare(_.downField(key.value.name)) |@| decodeTail.value).map(
+      (head, tail) => field[K](head) :: tail
+    )
+  )
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/ConfiguredDerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/ConfiguredDerivedDecoder.scala
@@ -3,7 +3,7 @@ package io.circe.generic.decoding
 import cats.data.Xor
 import cats.syntax.monoidal._
 import io.circe.{ AccumulatingDecoder, ConfiguredDecoder, Decoder, DecodingFailure, HCursor }
-import io.circe.generic.config.{ SnakeCaseKeys, snakeCase }
+import io.circe.generic.config.{ snakeCase, SnakeCaseKeys }
 import shapeless._, shapeless.labelled.{ FieldType, field }
 
 trait ConfiguredDerivedDecoder[C, A] extends DerivedDecoder[A] with ConfiguredDecoder[C, A]

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -1,82 +1,12 @@
 package io.circe.generic.decoding
 
-import cats.data.Xor
-import cats.syntax.monoidal._
-import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, HCursor }
-import shapeless._, shapeless.labelled.{ FieldType, field }
+import io.circe.Decoder
 
 trait DerivedDecoder[A] extends Decoder[A]
 
 @export.exports
-final object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedDecoders {
-  final def fromDecoder[A](decode: Decoder[A]): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode(c)
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-      decode.decodeAccumulating(c)
-  }
-
-  final implicit val decodeHNil: DerivedDecoder[HNil] =
-    new DerivedDecoder[HNil] {
-      final def apply(c: HCursor): Decoder.Result[HNil] = Xor.right(HNil)
-    }
-
-  implicit final val decodeCNil: DerivedDecoder[CNil] =
-    new DerivedDecoder[CNil] {
-      final def apply(c: HCursor): Decoder.Result[CNil] =
-        Xor.left(DecodingFailure("CNil", c.history))
-    }
-
-  implicit final def decodeCoproduct[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[Decoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
-    final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
-      c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
-        decodeTail.value(c).map(Inr(_))
-      ) { headJson =>
-        headJson.as(decodeHead.value).map(h => Inl(field(h)))
-      }
-  }
-
-  implicit final def decodeLabelledHList[K <: Symbol, H, T <: HList](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[Decoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :: T] = fromDecoder(
-    (decodeHead.value.prepare(_.downField(key.value.name)) |@| decodeTail.value).map(
-      (head, tail) => field[K](head) :: tail
-    )
-  )
-}
-
-private[circe] trait LowPriorityDerivedDecoders {
-  implicit final def decodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[DerivedDecoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
-    final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
-      c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
-        decodeTail.value(c).map(Inr(_))
-      ) { headJson =>
-        headJson.as(decodeHead.value).map(h => Inl(field(h)))
-      }
-  }
-
-  implicit final def decodeAdt[A, R <: Coproduct](implicit
-    gen: LabelledGeneric.Aux[A, R],
-    decode: Lazy[DerivedDecoder[R]]
-  ): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
-  }
-
-  implicit final def decodeCaseClass[A, R <: HList](implicit
-    gen: LabelledGeneric.Aux[A, R],
-    decode: Lazy[DerivedDecoder[R]]
-  ): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-      decode.value.decodeAccumulating(c).map(gen.from)
-  }
+final object DerivedDecoder {
+  implicit def upcastConfiguredDerivedDecoder[C, A](implicit
+    d: ConfiguredDerivedDecoder[C, A]
+  ): DerivedDecoder[A] = d
 }

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
@@ -6,7 +6,7 @@ import shapeless.{ HList, LabelledGeneric }
 import shapeless.ops.function.FnFromProduct
 import shapeless.ops.record.RemoveAll
 
-private[circe] trait IncompleteDerivedDecoders {
+private[circe] trait IncompleteDerivedDecoders extends LowPriorityIncompleteDerivedDecoders {
   implicit final def decodeIncompleteCaseClass[C, F, P <: HList, A, T <: HList, R <: HList](implicit
     ffp: FnFromProduct.Aux[P => A, F],
     gen: LabelledGeneric.Aux[A, T],
@@ -21,6 +21,28 @@ private[circe] trait IncompleteDerivedDecoders {
     gen: LabelledGeneric.Aux[A, R],
     patch: PatchWithOptions.Aux[R, O],
     decode: ConfiguredDerivedDecoder[C, O]
+  ): ConfiguredDerivedDecoder[C, A => A] = new ConfiguredDerivedDecoder[C, A => A] {
+    def apply(c: HCursor): Decoder.Result[A => A] =
+      decode(c).map(o => a => gen.from(patch(gen.to(a), o)))
+  }
+}
+
+private[circe] trait LowPriorityIncompleteDerivedDecoders {
+  implicit final
+    def decodeIncompleteCaseClassUnconfigured[C, F, P <: HList, A, T <: HList, R <: HList](implicit
+    ffp: FnFromProduct.Aux[P => A, F],
+    gen: LabelledGeneric.Aux[A, T],
+    removeAll: RemoveAll.Aux[T, P, (P, R)],
+    decode: DerivedDecoder[R]
+  ): ConfiguredDerivedDecoder[C, F] = new ConfiguredDerivedDecoder[C, F] {
+    def apply(c: HCursor): Decoder.Result[F] =
+      decode(c).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
+  }
+
+  implicit final def decodeCaseClassPatchUnconfigured[C, A, R <: HList, O <: HList](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    patch: PatchWithOptions.Aux[R, O],
+    decode: DerivedDecoder[O]
   ): ConfiguredDerivedDecoder[C, A => A] = new ConfiguredDerivedDecoder[C, A => A] {
     def apply(c: HCursor): Decoder.Result[A => A] =
       decode(c).map(o => a => gen.from(patch(gen.to(a), o)))

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/IncompleteDerivedDecoders.scala
@@ -7,21 +7,21 @@ import shapeless.ops.function.FnFromProduct
 import shapeless.ops.record.RemoveAll
 
 private[circe] trait IncompleteDerivedDecoders {
-  implicit final def decodeIncompleteCaseClass[F, P <: HList, A, T <: HList, R <: HList](implicit
+  implicit final def decodeIncompleteCaseClass[C, F, P <: HList, A, T <: HList, R <: HList](implicit
     ffp: FnFromProduct.Aux[P => A, F],
     gen: LabelledGeneric.Aux[A, T],
     removeAll: RemoveAll.Aux[T, P, (P, R)],
-    decode: DerivedDecoder[R]
-  ): DerivedDecoder[F] = new DerivedDecoder[F] {
+    decode: ConfiguredDerivedDecoder[C, R]
+  ): ConfiguredDerivedDecoder[C, F] = new ConfiguredDerivedDecoder[C, F] {
     def apply(c: HCursor): Decoder.Result[F] =
       decode(c).map(r => ffp(p => gen.from(removeAll.reinsert((p, r)))))
   }
 
-  implicit final def decodeCaseClassPatch[A, R <: HList, O <: HList](implicit
+  implicit final def decodeCaseClassPatch[C, A, R <: HList, O <: HList](implicit
     gen: LabelledGeneric.Aux[A, R],
     patch: PatchWithOptions.Aux[R, O],
-    decode: DerivedDecoder[O]
-  ): DerivedDecoder[A => A] = new DerivedDecoder[A => A] {
+    decode: ConfiguredDerivedDecoder[C, O]
+  ): ConfiguredDerivedDecoder[C, A => A] = new ConfiguredDerivedDecoder[C, A => A] {
     def apply(c: HCursor): Decoder.Result[A => A] =
       decode(c).map(o => a => gen.from(patch(gen.to(a), o)))
   }

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/ConfiguredDerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/ConfiguredDerivedObjectEncoder.scala
@@ -1,0 +1,124 @@
+package io.circe.generic.encoding
+
+import io.circe.{ ConfiguredEncoder, ConfiguredObjectEncoder, Encoder, JsonObject, ObjectEncoder }
+import io.circe.generic.config.{ SnakeCaseKeys, snakeCase }
+import shapeless._, shapeless.labelled.FieldType
+
+trait ConfiguredDerivedObjectEncoder[C, A]
+  extends DerivedObjectEncoder[A] with ConfiguredObjectEncoder[C, A]
+
+@export.exports
+final object ConfiguredDerivedObjectEncoder extends MidPriorityConfiguredDerivedObjectEncoders {
+  implicit final def encodeHNil[C]: ConfiguredDerivedObjectEncoder[C, HNil] =
+    new ConfiguredDerivedObjectEncoder[C, HNil] {
+      final def encodeObject(a: HNil): JsonObject = JsonObject.empty
+    }
+
+  implicit final def encodeCNil[C]: ConfiguredDerivedObjectEncoder[C, CNil] =
+    new ConfiguredDerivedObjectEncoder[C, CNil] {
+      final def encodeObject(a: CNil): JsonObject =
+        sys.error("No JSON representation of CNil (this shouldn't happen)")
+    }
+
+  implicit final def encodeCoproduct[C, K <: Symbol, H, T <: Coproduct](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[Encoder[H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[C, T]]
+  ): ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :+: T] =
+    new ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :+: T] {
+      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
+        case Inl(h) => JsonObject.singleton(
+          key.value.name,
+          encodeHead.value(h)
+        )
+        case Inr(t) => encodeTail.value.encodeObject(t)
+      }
+    }
+
+  implicit final def encodeLabelledHListSnakeCaseKeys[K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[ConfiguredObjectEncoder[SnakeCaseKeys, H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[SnakeCaseKeys, T]]
+  ): ConfiguredDerivedObjectEncoder[SnakeCaseKeys, FieldType[K, H] :: T] =
+    new ConfiguredDerivedObjectEncoder[SnakeCaseKeys, FieldType[K, H] :: T] {
+      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
+        case h :: t =>
+          (snakeCase(key.value.name) -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
+      }
+    }
+}
+
+private[circe] trait MidPriorityConfiguredDerivedObjectEncoders
+  extends LowPriorityConfiguredDerivedObjectEncoders {
+  implicit final def encodeCoproductDerived[C, K <: Symbol, H, T <: Coproduct](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[ConfiguredDerivedObjectEncoder[C, H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[C, T]]
+  ): ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :+: T] =
+    new ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :+: T] {
+      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
+        case Inl(h) => JsonObject.singleton(
+          key.value.name,
+          encodeHead.value(h)
+        )
+        case Inr(t) => encodeTail.value.encodeObject(t)
+      }
+    }
+
+  implicit final def encodeLabelledHListSnakeCaseKeysBase[K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[Encoder[H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[SnakeCaseKeys, T]]
+  ): ConfiguredDerivedObjectEncoder[SnakeCaseKeys, FieldType[K, H] :: T] =
+    new ConfiguredDerivedObjectEncoder[SnakeCaseKeys, FieldType[K, H] :: T] {
+      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
+        case h :: t =>
+          (snakeCase(key.value.name) -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
+      }
+    }
+
+  implicit final def encodeAdt[C, A, R <: Coproduct](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    encode: Lazy[ConfiguredDerivedObjectEncoder[C, R]]
+  ): ConfiguredDerivedObjectEncoder[C, A] =
+    new ConfiguredDerivedObjectEncoder[C, A] {
+      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
+    }
+
+  implicit final def encodeCaseClass[C, A, R <: HList](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    encode: Lazy[ConfiguredDerivedObjectEncoder[C, R]]
+  ): ConfiguredDerivedObjectEncoder[C, A] =
+    new ConfiguredDerivedObjectEncoder[C, A] {
+      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
+    }
+}
+
+private[circe] trait LowPriorityConfiguredDerivedObjectEncoders extends
+  LowestPriorityConfiguredDerivedObjectEncoders {
+  implicit final def encodeLabelledHListUnconfigured[C, K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[ConfiguredEncoder[C, H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[C, T]]
+  ): ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :: T] =
+    new ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :: T] {
+      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
+        case h :: t =>
+          (key.value.name -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
+      }
+    }
+}
+
+private[circe] trait LowestPriorityConfiguredDerivedObjectEncoders {
+  implicit final def encodeLabelledHListUnconfiguredBase[C, K <: Symbol, H, T <: HList](implicit
+    key: Witness.Aux[K],
+    encodeHead: Lazy[Encoder[H]],
+    encodeTail: Lazy[ConfiguredDerivedObjectEncoder[C, T]]
+  ): ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :: T] =
+    new ConfiguredDerivedObjectEncoder[C, FieldType[K, H] :: T] {
+      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
+        case h :: t =>
+          (key.value.name -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
+      }
+    }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/ConfiguredDerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/ConfiguredDerivedObjectEncoder.scala
@@ -1,7 +1,7 @@
 package io.circe.generic.encoding
 
 import io.circe.{ ConfiguredEncoder, ConfiguredObjectEncoder, Encoder, JsonObject, ObjectEncoder }
-import io.circe.generic.config.{ SnakeCaseKeys, snakeCase }
+import io.circe.generic.config.{ snakeCase, SnakeCaseKeys }
 import shapeless._, shapeless.labelled.FieldType
 
 trait ConfiguredDerivedObjectEncoder[C, A]

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -1,80 +1,12 @@
 package io.circe.generic.encoding
 
-import io.circe.{ Encoder, JsonObject, ObjectEncoder }
-import shapeless._, shapeless.labelled.FieldType
+import io.circe.ObjectEncoder
 
 trait DerivedObjectEncoder[A] extends ObjectEncoder[A]
 
 @export.exports
-final object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
-  implicit final val encodeHNil: DerivedObjectEncoder[HNil] =
-    new DerivedObjectEncoder[HNil] {
-      final def encodeObject(a: HNil): JsonObject = JsonObject.empty
-    }
-
-  implicit final val encodeCNil: DerivedObjectEncoder[CNil] =
-    new DerivedObjectEncoder[CNil] {
-      final def encodeObject(a: CNil): JsonObject =
-        sys.error("No JSON representation of CNil (this shouldn't happen)")
-    }
-
-  implicit final def encodeCoproduct[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[Encoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :+: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :+: T] {
-      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
-        case Inl(h) => JsonObject.singleton(
-          key.value.name,
-          encodeHead.value(h)
-        )
-        case Inr(t) => encodeTail.value.encodeObject(t)
-      }
-    }
-
-  implicit final def encodeLabelledHList[K <: Symbol, H, T <: HList](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[Encoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :: T] {
-      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
-        case h :: t =>
-          (key.value.name -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
-      }
-    }
-}
-
-private[circe] trait LowPriorityDerivedObjectEncoders {
-  implicit final def encodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[DerivedObjectEncoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :+: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :+: T] {
-      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
-        case Inl(h) => JsonObject.singleton(
-          key.value.name,
-          encodeHead.value(h)
-        )
-        case Inr(t) => encodeTail.value.encodeObject(t)
-      }
-    }
-
-  implicit final def encodeAdt[A, R <: Coproduct](implicit
-    gen: LabelledGeneric.Aux[A, R],
-    encode: Lazy[DerivedObjectEncoder[R]]
-  ): DerivedObjectEncoder[A] =
-    new DerivedObjectEncoder[A] {
-      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
-    }
-
-  implicit final def encodeCaseClass[A, R <: HList](implicit
-    gen: LabelledGeneric.Aux[A, R],
-    encode: Lazy[DerivedObjectEncoder[R]]
-  ): DerivedObjectEncoder[A] =
-    new DerivedObjectEncoder[A] {
-      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
-    }
+final object DerivedObjectEncoder {
+  implicit def upcastConfiguredDerivedObjectEncoder[C, A](implicit
+    d: ConfiguredDerivedObjectEncoder[C, A]
+  ): DerivedObjectEncoder[A] = d
 }

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -56,13 +56,15 @@ final object semiauto {
       ffp: FnFromProduct.Aux[P => C, A],
       gen: LabelledGeneric.Aux[C, T],
       removeAll: RemoveAll.Aux[T, P, (P, R)],
-      decode: ConfiguredDerivedDecoder[Nothing, R]
-    ): Decoder[A] = ConfiguredDerivedDecoder.decodeIncompleteCaseClass[Nothing, A, P, C, T, R]
+      decode: DerivedDecoder[R]
+    ): Decoder[A] =
+      ConfiguredDerivedDecoder.decodeIncompleteCaseClassUnconfigured[Nothing, A, P, C, T, R]
 
     final def patch[R <: HList, O <: HList](implicit
       gen: LabelledGeneric.Aux[A, R],
       patch: PatchWithOptions.Aux[R, O],
-      decode: ConfiguredDerivedDecoder[Nothing, O]
-    ): DerivedDecoder[A => A] = ConfiguredDerivedDecoder.decodeCaseClassPatch[Nothing, A, R, O]
+      decode: DerivedDecoder[O]
+    ): DerivedDecoder[A => A] =
+      ConfiguredDerivedDecoder.decodeCaseClassPatchUnconfigured[Nothing, A, R, O]
   }
 }

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -1,7 +1,7 @@
 package io.circe.generic
 
 import io.circe.{ Decoder, HCursor, JsonObject, ObjectEncoder }
-import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.decoding.{ ConfiguredDerivedDecoder, DerivedDecoder }
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.util.PatchWithOptions
 import shapeless.{ HList, LabelledGeneric, Lazy }
@@ -56,13 +56,13 @@ final object semiauto {
       ffp: FnFromProduct.Aux[P => C, A],
       gen: LabelledGeneric.Aux[C, T],
       removeAll: RemoveAll.Aux[T, P, (P, R)],
-      decode: DerivedDecoder[R]
-    ): Decoder[A] = DerivedDecoder.decodeIncompleteCaseClass[A, P, C, T, R]
+      decode: ConfiguredDerivedDecoder[Nothing, R]
+    ): Decoder[A] = ConfiguredDerivedDecoder.decodeIncompleteCaseClass[Nothing, A, P, C, T, R]
 
     final def patch[R <: HList, O <: HList](implicit
       gen: LabelledGeneric.Aux[A, R],
       patch: PatchWithOptions.Aux[R, O],
-      decode: DerivedDecoder[O]
-    ): DerivedDecoder[A => A] = DerivedDecoder.decodeCaseClassPatch[A, R, O]
+      decode: ConfiguredDerivedDecoder[Nothing, O]
+    ): DerivedDecoder[A => A] = ConfiguredDerivedDecoder.decodeCaseClassPatch[Nothing, A, R, O]
   }
 }


### PR DESCRIPTION
This morning @notxcain [asked about the status](https://gitter.im/travisbrown/circe?at=56939d6a0712a5b63b4cb612) of configuration for generic derivation, and I wanted to go ahead and post this branch since I think it's the most promising approach I've tried so far (although it's a long way from done). Usage looks like this:

```scala
import io.circe._, io.circe.generic.auto._, io.circe.jawn._, io.circe.syntax._
import io.circe.generic.config.SnakeCaseKeys

case class Qux(thisIsAFieldWithALongName: Int, anotherField: String)
```

And then:

```scala
scala> val json = Qux(13, "abcd").asJson
json: io.circe.Json =
{
  "thisIsAFieldWithALongName" : 13,
  "anotherField" : "abcd"
}

scala> val snakeCaseJson = Qux(13, "abcd").asJsonConfigured[SnakeCaseKeys]
snakeCaseJson: io.circe.Json =
{
  "this_is_a_field_with_a_long_name" : 13,
  "another_field" : "abcd"
}

scala> decode[Qux](json.noSpaces)
res0: cats.data.Xor[io.circe.Error,Qux] = Right(Qux(13,abcd))

scala> decodeConfigured[Qux, SnakeCaseKeys](snakeCaseJson.noSpaces)
res1: cats.data.Xor[io.circe.Error,Qux] = Right(Qux(13,abcd))
```

The code above actually works and all tests pass unchanged, but there are a few problems:

1. Composing configuration: ideally something like `decodeConfigured[Qux, SnakeCaseKeys with FieldDiscriminators](...)` should work, but I've run into problems trying to get there.
2. Nested derived instances: getting the prioritization right (not stepping on user-defined instances but passing configuration into nested case classes) for this is a mess, and it's currently broken (I had it working at some point at the expense of some trade-off that I don't remember at the moment).
3. It makes compilation even slower, even for non-configured instances. I don't want to merge any version of this that hurts the compilation speed for non-configured instances.
