### PR TITLE
Add beginning of java8 module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,14 @@ cache:
 
 script:
   - if [[ "$TRAVIS_BRANCH" == "scalajs" ]];
-      then sbt ++$TRAVIS_SCALA_VERSION clean validateJS;
-      else sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM coverageReport;
+    then sbt ++$TRAVIS_SCALA_VERSION clean validateJS;
+    else
+      sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM &&
+      if [[ "$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}')" < "1.8" ]];
+        then echo "Skipping circe-java8 build and tests";
+        else sbt ++$TRAVIS_SCALA_VERSION java8/test;
+      fi &&
+      sbt ++$TRAVIS_SCALA_VERSION coverageReport;
     fi
 
   # See http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html

--- a/build.sbt
+++ b/build.sbt
@@ -78,8 +78,9 @@ lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Se
       async,
       benchmark,
       coreJS,
-      literal, literalJS,
       genericJS,
+      java8,
+      literal, literalJS,
       refinedJS,
       parseJS,
       tests,
@@ -256,6 +257,14 @@ lazy val jawn = project
     libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.3"
   )
   .dependsOn(core)
+
+lazy val java8 = project
+  .settings(
+    description := "circe java8",
+    moduleName := "circe-java8"
+  )
+  .settings(allSettings)
+  .dependsOn(core, tests % "test")
 
 lazy val streaming = project
   .settings(

--- a/java8/src/main/scala/io/circe/java8/package.scala
+++ b/java8/src/main/scala/io/circe/java8/package.scala
@@ -1,0 +1,25 @@
+package io.circe
+
+import cats.data.Xor
+import java.time.LocalDateTime
+import java.time.format.{ DateTimeFormatter, DateTimeParseException }
+
+package object java8 {
+  final def decodeLocalDateTime(formatter: DateTimeFormatter): Decoder[LocalDateTime] =
+    Decoder.instance { c =>
+      c.as[String].flatMap { s =>
+        try Xor.right(LocalDateTime.parse(s, formatter)) catch {
+          case _: DateTimeParseException => Xor.left(DecodingFailure("LocalDateTime", c.history))
+        }
+      }
+    }
+
+  final def encodeLocalDateTime(formatter: DateTimeFormatter): Encoder[LocalDateTime] =
+    Encoder.instance(time => Json.string(time.format(formatter)))
+
+  implicit final val decodeLocalDateTimeDefault: Decoder[LocalDateTime] =
+    decodeLocalDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+  implicit final val encodeLocalDateTimeDefault: Encoder[LocalDateTime] =
+    encodeLocalDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+}

--- a/java8/src/test/scala/io/circe/java8/LocalDateTimeCodecSuite.scala
+++ b/java8/src/test/scala/io/circe/java8/LocalDateTimeCodecSuite.scala
@@ -1,0 +1,19 @@
+package io.circe.java8
+
+import algebra.Eq
+import io.circe.tests.{ CodecTests, CirceSuite }
+import java.time.{ LocalDateTime, ZoneId }
+import java.util.Date
+import org.scalacheck.Arbitrary
+
+class LocalDateTimeCodecSuite extends CirceSuite {
+  implicit val localDateTimeArbitrary: Arbitrary[LocalDateTime] = Arbitrary(
+    Arbitrary.arbitrary[Date].map(date =>
+      LocalDateTime.ofInstant(date.toInstant, ZoneId.systemDefault)
+    )
+  )
+
+  implicit val localDateTimeEq: Eq[LocalDateTime] = Eq.fromUniversalEquals
+
+  checkAll("Codec[LocalDateTime]", CodecTests[LocalDateTime].codec)
+}


### PR DESCRIPTION
Right now this only includes instances for `LocalDateTime`:

```scala
scala> import io.circe._, io.circe.java8._, java.time.LocalDateTime
import io.circe._
import io.circe.java8._
import java.time.LocalDateTime

scala> val json = Encoder[LocalDateTime].apply(LocalDateTime.now)
json: io.circe.Json = "2016-01-15T13:27:46.64"

scala> Decoder[LocalDateTime].apply(json.hcursor)
res0: io.circe.Decoder.Result[java.time.LocalDateTime] = Right(2016-01-15T13:27:46.640)
```

Note that this module won't work on Java 7 or earlier, and isn't available for Scala.js.

I'd also like to add some other things like helpers for creating encoder and decoder instances from Java with lambda expressions, but I'm happy to merge this as is for now.

I'm not 100% sure the Travis CI config will work correctly (I hate Bash), and it's taking jobs forever to get started today, so I may be force pushing fixes to this branch until I get it working.