### PR TITLE
Deep merge operation

### DIFF
--- a/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -1,0 +1,20 @@
+package io.circe
+
+import io.circe.tests.CirceSuite
+
+class JsonSuite extends CirceSuite {
+
+  test("deepmerge preserves argument order") {
+    check { (js: List[Json]) =>
+      val fields = js.zipWithIndex.map {
+        case (j, i) => i.toString -> j
+      }
+
+      val reversed = Json.fromFields(fields.reverse)
+      val merged   = Json.fromFields(fields).deepMerge(reversed)
+
+      merged.asObject.map { _.toList } === Some(fields.reverse)
+    }
+  }
+
+}


### PR DESCRIPTION
Here's my initial attempt at adding the deepmerge method to the Json class. While almost identical to the corresponding method in Argonaut.Json, as per the discussion [here] (https://gitter.im/travisbrown/circe?at=56915002ee13050b38a293b3) and [here](https://github.com/travisbrown/circe/issues/169), this implementation ensures that the fields in the Json argument consistently take precedence.


