### PR TITLE
Renaming of cats.syntax.monoidal to cats.syntax.cartesian

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -3,8 +3,8 @@ package io.circe
 import cats.Monad
 import cats.data.{ Kleisli, NonEmptyList, Validated, Xor }
 import cats.std.list._
+import cats.syntax.cartesian._
 import cats.syntax.functor._
-import cats.syntax.monoidal._
 import java.util.UUID
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -1,7 +1,7 @@
 package io.circe.generic.decoding
 
 import cats.data.Xor
-import cats.syntax.monoidal._
+import cats.syntax.cartesian._
 import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, HCursor }
 import shapeless._, shapeless.labelled.{ FieldType, field }
 


### PR DESCRIPTION
cats.syntax.monoidal has been renamed to cats.syntax.cartesian - the modifications here simply reflect that change.