### PR TITLE
Implement OneAnd[F, A] instances for collection-like F

### DIFF
--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -1,10 +1,10 @@
 package io.circe
 
-import cats.data.{ NonEmptyList, Validated, Xor }
+import cats.data._
 import cats.functor.Contravariant
-import cats.std.list._
 import cats.Foldable
 import java.util.UUID
+import scala.collection.GenSeq
 import scala.collection.generic.IsTraversableOnce
 import scala.collection.mutable.ArrayBuffer
 
@@ -188,8 +188,12 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   /**
    * @group Encoding
    */
-  implicit final def encodeNonEmptyList[A: Encoder]: Encoder[NonEmptyList[A]] =
-    fromFoldable[NonEmptyList, A]
+  implicit final def encodeOneAnd[A0, C[_]](
+    implicit ea: Encoder[A0],
+    is: IsTraversableOnce[C[A0]] { type A = A0 }
+  ): Encoder[OneAnd[C, A0]] = encodeTraversableOnce[A0, GenSeq].contramap[OneAnd[C, A0]] {
+    oneAnd => oneAnd.head +: is.conversion(oneAnd.tail).toSeq
+  }
 
   /**
    * @group Encoding

--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -1,6 +1,6 @@
 package io.circe.tests
 
-import cats.data.NonEmptyList
+import cats.data.OneAnd
 import io.circe.{ Json, JsonBigDecimal, JsonDouble, JsonLong, JsonNumber, JsonObject }
 import io.circe.Json.{ JArray, JNumber, JObject, JString }
 import java.util.UUID
@@ -104,10 +104,12 @@ trait ArbitraryInstances {
     )
   )
 
-  implicit def oneAndArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[NonEmptyList[A]] = Arbitrary(
+  implicit def oneAndArbitrary[A, C[_]](implicit
+    A: Arbitrary[A], CA: Arbitrary[C[A]]
+  ): Arbitrary[OneAnd[C, A]] = Arbitrary(
     for {
       h <- A.arbitrary
-      t <- Arbitrary.arbitrary[List[A]]
-    } yield NonEmptyList(h, t)
+      t <- CA.arbitrary
+    } yield OneAnd(h, t)
   )
 }

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -2,7 +2,7 @@ package io.circe
 
 import java.util.UUID
 
-import cats.data.{ NonEmptyList, Validated, Xor }
+import cats.data._
 import cats.laws.discipline.arbitrary._
 import io.circe.tests.{ CodecTests, CirceSuite }
 
@@ -80,6 +80,8 @@ class StdLibCodecSuite extends CirceSuite {
 
 class CatsCodecSuite extends CirceSuite {
   checkAll("Codec[NonEmptyList[Int]]", CodecTests[NonEmptyList[Int]].codec)
+  checkAll("Codec[NonEmptyVector[Int]]", CodecTests[NonEmptyVector[Int]].codec)
+  checkAll("Codec[NonEmptyStream[Int]]", CodecTests[NonEmptyStream[Int]].codec)
 }
 
 class CirceCodecSuite extends CirceSuite {


### PR DESCRIPTION
Addresses #170 

Some reasoning behind changes:

1. I'm targeting only collection-like `F`s as it's not perfectly clear to me what should be a generic representation of `OneAnd[F, A]` where `F` is just some arbitrary type constructor. Anyway all the fun starts only when `F` is at least `Foldable`.
2. I decided to target collections from `std` lib, instead of implementing instances in terms of `cats` typeclasses for a couple reasons:
    1. Getting instances for `NonEmptyList/Vector/Stream` will require end-users to import `cats.std.list/vector/stream._` which is not convenient. Targeting `IsTraversableOnce` on the other hand will automagically generate instances for standard collections, which is a major use-case AFAIU.
    2. Just replacing an instance for `NonEmptyList[A]` with an instance for `OneAnd[F, A]` can break code in a subtle way if automatic derivation is involved. Consider the following snippet:

```scala
import io.circe._
import io.circe.generic.auto._

val nel: NonEmptyList[Int] = NonEmptyList(1, 2)

// Before: encoder for NEL is implemented directly and doesn't require any additional imports
val e = Encoder[NonEmptyList[Int]]
e(nel) // "[1, 2]"

// After: encoder for NEL is implemented in terms of OneAnd and requires import from cats
val e = Encoder[NonEmptyList[Int]] // generic derivation kicks in because no foldable for list is provided
e(nel) // "{head: 1, tail: [2]}"
```

Might not be very generic. But on the bright-side we get very good performance comparable to that of regular collections. Locally I got ~3% difference:
```
[info] Benchmark                          Mode  Cnt     Score    Error  Units
[info] EncodingBenchmark.encodeFooNelsC  thrpt   20  4875.958 ± 74.492  ops/s
[info] EncodingBenchmark.encodeFoosC     thrpt   20  5039.914 ± 72.708  ops/s
```