### PR TITLE
Updates for iteratee.io 0.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ lazy val circe = project.in(file("."))
     jawn,
     jackson,
     optics,
+    streaming,
     async,
     benchmark
   )
@@ -276,7 +277,7 @@ lazy val streaming = project
   )
   .settings(allSettings)
   .settings(
-    libraryDependencies += "io.iteratee" %% "iteratee-task" % "0.2.0-SNAPSHOT"
+    libraryDependencies += "io.iteratee" %% "iteratee-task" % "0.2.0"
   )
   .dependsOn(core, jawn)
 

--- a/examples/sf-city-lots/README.md
+++ b/examples/sf-city-lots/README.md
@@ -24,15 +24,6 @@ awk 'BEGIN{print"["} NR>4 {print l} {l=$0}' citylots.json > data.json
 
 (You can also do this by hand, of course.)
 
-You'll also need to publish `circe-streaming` locally, since it's not yet in the 0.3.0 snapshot. You
-can do this by typing the following command in the root project directory:
-
-```bash
-sbt "project streaming" publishLocal
-```
-
-(This second step will soon be unnecessary.)
-
 ## Decoders
 
 Next we'll define our decoders for the JSON representation of the shapefile. We'll start with our

--- a/examples/sf-city-lots/build.sbt
+++ b/examples/sf-city-lots/build.sbt
@@ -7,5 +7,5 @@ scalacOptions += "-deprecation"
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % "0.3.0-SNAPSHOT",
   "io.circe" %% "circe-streaming" % "0.3.0-SNAPSHOT",
-  "io.iteratee" %% "iteratee-task" % "0.2.0-SNAPSHOT"
+  "io.iteratee" %% "iteratee-task" % "0.2.0"
 )

--- a/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
+++ b/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
@@ -7,8 +7,8 @@ import cats.std.vector._
 import cats.syntax.traverse._
 import io.circe.{ Json, ParsingFailure }
 import io.circe.jawn.CirceSupportParser
-import io.iteratee.internal.Step
 import io.iteratee.{ Enumeratee, Iteratee }
+import io.iteratee.internal.Step
 
 private[streaming] abstract class ParsingEnumeratee[F[_], S](implicit F: MonadError[F, Throwable])
   extends Enumeratee[F, S, Json] {


### PR DESCRIPTION
I've just released iteratee.io 0.2.0, so I'm now aggregating circe-streaming and publishing it with the snapshot, although it still needs tests before 0.3.0.