### PR TITLE
Rename parse module and package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ you can just add the following to your build:
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % "0.2.1",
   "io.circe" %% "circe-generic" % "0.2.1",
-  "io.circe" %% "circe-parse" % "0.2.1"
+  "io.circe" %% "circe-parser" % "0.2.1"
 )
 ```
 
@@ -56,10 +56,10 @@ Then type `sbt console` to start a REPL and then paste the following (this will 
 root directory of this repository):
 
 ```scala
-scala> import io.circe._, io.circe.generic.auto._, io.circe.parse._, io.circe.syntax._
+scala> import io.circe._, io.circe.generic.auto._, io.circe.parser._, io.circe.syntax._
 import io.circe._
 import io.circe.generic.auto._
-import io.circe.parse._
+import io.circe.parser._
 import io.circe.syntax._
 
 scala> sealed trait Foo
@@ -110,7 +110,7 @@ facade. Jawn is fast, it offers asynchronous parsing, and best of all it lets us
 fussiest code in Argonaut. The [`jackson`][circe-jackson] subproject supports using
 [Jackson][jackson] for both parsing and printing.
 
-circe also provides a [`parse`][circe-parse] subproject that provides parsing support for Scala.js,
+circe also provides a [`parser`][circe-parser] subproject that provides parsing support for Scala.js,
 with JVM parsing provided by `io.circe.jawn` and JavaScript parsing from `scalajs.js.JSON`.
 
 ### Lenses
@@ -361,7 +361,7 @@ limitations under the License.
 [circe-generic]: https://travisbrown.github.io/circe/api/#io.circe.generic.auto$
 [circe-jackson]: https://travisbrown.github.io/circe/api/#io.circe.jackson.package
 [circe-jawn]: https://travisbrown.github.io/circe/api/#io.circe.jawn.package
-[circe-parse]: https://travisbrown.github.io/circe/api/#io.circe.parse.package
+[circe-parser]: https://travisbrown.github.io/circe/api/#io.circe.parser.package
 [code-of-conduct]: http://typelevel.org/conduct.html
 [discipline]: https://github.com/typelevel/discipline
 [encoder]: https://travisbrown.github.io/circe/api/#io.circe.Encoder$

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ circe is published to [Maven Central][maven-central] and cross-built for Scala 2
 you can just add the following to your build:
 
 ```scala
+resolvers += Resolver.sonatypeRepo("snapshots")
+
 libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core" % "0.2.1",
-  "io.circe" %% "circe-generic" % "0.2.1",
-  "io.circe" %% "circe-parser" % "0.2.1"
+  "io.circe" %% "circe-core" % "0.3.0-SNAPSHOT",
+  "io.circe" %% "circe-generic" % "0.3.0-SNAPSHOT",
+  "io.circe" %% "circe-parser" % "0.3.0-SNAPSHOT"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val docSettings = site.settings ++ ghpages.settings ++ unidocSettings ++ Se
       java8,
       literal, literalJS,
       refinedJS,
-      parseJS,
+      parserJS,
       tests,
       testsJS
     )
@@ -98,7 +98,7 @@ lazy val circe = project.in(file("."))
         |import io.circe._
         |import io.circe.generic.auto._
         |import io.circe.literal._
-        |import io.circe.parse._
+        |import io.circe.parser._
         |import io.circe.syntax._
         |import cats.data.Xor
       """.stripMargin
@@ -108,7 +108,7 @@ lazy val circe = project.in(file("."))
     generic, genericJS,
     literal, literalJS,
     refined, refinedJS,
-    parse, parseJS,
+    parser, parserJS,
     tests, testsJS,
     jawn,
     jackson,
@@ -117,7 +117,7 @@ lazy val circe = project.in(file("."))
     async,
     benchmark
   )
-  .dependsOn(core, generic, literal, parse)
+  .dependsOn(core, generic, literal, parser)
 
 lazy val coreBase = crossProject.in(file("core"))
   .settings(
@@ -199,20 +199,20 @@ lazy val refinedBase = crossProject.in(file("refined"))
 lazy val refined = refinedBase.jvm
 lazy val refinedJS = refinedBase.js
 
-lazy val parseBase = crossProject.in(file("parse"))
+lazy val parserBase = crossProject.in(file("parser"))
   .settings(
-    description := "circe parse",
-    moduleName := "circe-parse",
-    name := "parse"
+    description := "circe parser",
+    moduleName := "circe-parser",
+    name := "parser"
   )
   .settings(allSettings: _*)
   .jsSettings(commonJsSettings: _*)
-  .jvmConfigure(_.copy(id = "parse").dependsOn(jawn))
-  .jsConfigure(_.copy(id = "parseJS"))
+  .jvmConfigure(_.copy(id = "parser").dependsOn(jawn))
+  .jsConfigure(_.copy(id = "parserJS"))
   .dependsOn(coreBase)
 
-lazy val parse = parseBase.jvm
-lazy val parseJS = parseBase.js
+lazy val parser = parserBase.jvm
+lazy val parserJS = parserBase.js
 
 lazy val testsBase = crossProject.in(file("tests"))
   .settings(
@@ -246,7 +246,7 @@ lazy val testsBase = crossProject.in(file("tests"))
       libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.8.3" % "compile-time"
     )
   )
-  .dependsOn(coreBase, genericBase, literalBase, refinedBase, parseBase)
+  .dependsOn(coreBase, genericBase, literalBase, refinedBase, parserBase)
 
 lazy val tests = testsBase.jvm
 lazy val testsJS = testsBase.js
@@ -412,7 +412,7 @@ val jvmProjects = Seq(
   "core",
   "generic",
   "refined",
-  "parse",
+  "parser",
   "tests",
   "jawn",
   "jackson",
@@ -424,7 +424,7 @@ val jsProjects = Seq(
   "coreJS",
   "genericJS",
   "refinedJS",
-  "parseJS",
+  "parserJS",
   "testsJS"
 )
 

--- a/parser/js/src/main/scala/io/circe/parser/package.scala
+++ b/parser/js/src/main/scala/io/circe/parser/package.scala
@@ -10,7 +10,7 @@ import scalajs.js.{
   SyntaxError
 }
 
-package object parse extends Parser {
+package object parser extends Parser {
   def parse(input: String): Xor[ParsingFailure, Json] = try {
     Xor.right(convertJson(JSON.parse(input)))
   } catch {

--- a/parser/jvm/src/main/scala/io/circe/parser/package.scala
+++ b/parser/jvm/src/main/scala/io/circe/parser/package.scala
@@ -3,7 +3,7 @@ package io.circe
 import cats.data.Xor
 import io.circe.jawn.JawnParser
 
-package object parse extends Parser {
+package object parser extends Parser {
   private[this] val parser = new JawnParser
 
   def parse(input: String): Xor[ParsingFailure, Json] = parser.parse(input)

--- a/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/PrinterSuites.scala
@@ -2,6 +2,6 @@ package io.circe
 
 import io.circe.tests.PrinterSuite
 
-class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parse.`package`)
-class Spaces2PrinterSuite extends PrinterSuite(Printer.noSpaces, parse.`package`)
-class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parse.`package`)
+class NoSpacesPrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`)
+class Spaces2PrinterSuite extends PrinterSuite(Printer.noSpaces, parser.`package`)
+class Spaces4PrinterSuite extends PrinterSuite(Printer.spaces4, parser.`package`)

--- a/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/SerializableSuite.scala
@@ -28,6 +28,6 @@ class SerializableSuite extends CirceSuite {
   	SerializableTests.serializable(ObjectEncoder[Map[String, Int]])
   )
 
-  checkAll("Parser", SerializableTests.serializable(parse.`package`))
+  checkAll("Parser", SerializableTests.serializable(parser.`package`))
   checkAll("Printer", SerializableTests.serializable(Printer.noSpaces))
 }

--- a/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
@@ -2,7 +2,7 @@ package io.circe.literal
 
 import cats.data.Xor
 import io.circe.Json
-import io.circe.parse.parse
+import io.circe.parser.parse
 import io.circe.tests.CirceSuite
 import shapeless.test.illTyped
 

--- a/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
@@ -1,4 +1,4 @@
-package io.circe.parse
+package io.circe.parser
 
 import io.circe.tests.{ CirceSuite, ParserTests }
 


### PR DESCRIPTION
The `parse` module is currently provided to support cross-platform code, with the implementation provided by jawn on the JVM and `scalajs.js.JSON` on Scala.js. Unfortunately the package name is a little inconvenient, since we have both a `parse` package and a `parse` method that we may end up importing into the same scope (see e.g. #175).

This PR renames the `parse` module and package to `parser`. This is a fairly big breaking change, and I'm doing it without a deprecation cycle, but the upgrade is trivial, and I think it'd be better to get this over with now.