### PR TITLE
Overhaul Json API

### DIFF
--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -114,7 +114,7 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   /**
    * @group Encoding
    */
-  implicit final val encodeString: Encoder[String] = instance(Json.string)
+  implicit final val encodeString: Encoder[String] = instance(Json.fromString)
 
   /**
    * @group Encoding
@@ -124,66 +124,63 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   /**
    * @group Encoding
    */
-  implicit final val encodeBoolean: Encoder[Boolean] = instance(Json.bool)
+  implicit final val encodeBoolean: Encoder[Boolean] = instance(Json.fromBoolean)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeChar: Encoder[Char] = instance(a => Json.string(a.toString))
+  implicit final val encodeChar: Encoder[Char] = instance(a => Json.fromString(a.toString))
 
   /**
    * @group Encoding
    */
-  implicit final val encodeFloat: Encoder[Float] =
-    instance(a => JsonDouble(a.toDouble).asJsonOrNull)
+  implicit final val encodeFloat: Encoder[Float] = instance(a => Json.fromDoubleOrNull(a.toDouble))
 
   /**
    * @group Encoding
    */
-  implicit final val encodeDouble: Encoder[Double] = instance(a => JsonDouble(a).asJsonOrNull)
+  implicit final val encodeDouble: Encoder[Double] = instance(Json.fromDoubleOrNull)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeByte: Encoder[Byte] = instance(a => Json.JNumber(JsonLong(a.toLong)))
+  implicit final val encodeByte: Encoder[Byte] = instance(a => Json.fromInt(a.toInt))
 
   /**
    * @group Encoding
    */
-  implicit final val encodeShort: Encoder[Short] = instance(a => Json.JNumber(JsonLong(a.toLong)))
+  implicit final val encodeShort: Encoder[Short] = instance(a => Json.fromInt(a.toInt))
 
   /**
    * @group Encoding
    */
-  implicit final val encodeInt: Encoder[Int] = instance(a => Json.JNumber(JsonLong(a.toLong)))
+  implicit final val encodeInt: Encoder[Int] = instance(Json.fromInt)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeLong: Encoder[Long] = instance(a => Json.JNumber(JsonLong(a)))
+  implicit final val encodeLong: Encoder[Long] = instance(Json.fromLong)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeBigInt: Encoder[BigInt] =
-    instance(a => JsonBigDecimal(BigDecimal(a, java.math.MathContext.UNLIMITED)).asJsonOrNull)
+  implicit final val encodeBigInt: Encoder[BigInt] = instance(Json.fromBigInt)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeBigDecimal: Encoder[BigDecimal] =
-    instance(a => JsonBigDecimal(a).asJsonOrNull)
+  implicit final val encodeBigDecimal: Encoder[BigDecimal] = instance(Json.fromBigDecimal)
 
   /**
    * @group Encoding
    */
-  implicit final val encodeUUID: Encoder[UUID] = instance(a => Json.string(a.toString))
+  implicit final val encodeUUID: Encoder[UUID] = instance(a => Json.fromString(a.toString))
 
   /**
    * @group Encoding
    */
   implicit final def encodeOption[A](implicit e: Encoder[A]): Encoder[Option[A]] =
-    instance(_.fold(Json.empty)(e(_)))
+    instance(_.fold(Json.Null)(e(_)))
 
   /**
    * @group Encoding

--- a/core/shared/src/main/scala/io/circe/Json.scala
+++ b/core/shared/src/main/scala/io/circe/Json.scala
@@ -296,27 +296,90 @@ final object Json {
   final val True: Json = JBoolean(true)
   final val False: Json = JBoolean(false)
 
+  /**
+   * Create a `Json` value representing a JSON object from key-value pairs.
+   */
   final def obj(fields: (String, Json)*): Json = fromFields(fields)
+
+  /**
+   * Create a `Json` value representing a JSON array from values.
+   */
   final def arr(values: Json*): Json = fromValues(values)
 
+  /**
+   * Create a `Json` value representing a JSON object from a collection of key-value pairs.
+   */
   final def fromFields(fields: Iterable[(String, Json)]): Json = JObject(JsonObject.fromIterable(fields))
+
+  /**
+   * Create a `Json` value representing a JSON array from a collection of values.
+   */
   final def fromValues(values: Iterable[Json]): Json = JArray(values.toList)
 
+  /**
+   * Create a `Json` value representing a JSON object from a [[JsonObject]].
+   */
   final def fromJsonObject(value: JsonObject): Json = JObject(value)
+
+  /**
+   * Create a `Json` value representing a JSON number from a [[JsonNumber]].
+   */
   final def fromJsonNumber(value: JsonNumber): Json = JNumber(value)
 
+  /**
+   * Create a `Json` value representing a JSON string.
+   *
+   * Note that this does not parse the argument.
+   */
   final def fromString(value: String): Json = JString(value)
+
+  /**
+   * Create a `Json` value representing a JSON boolean.
+   */
   final def fromBoolean(value: Boolean): Json = JBoolean(value)
 
+  /**
+   * Create a `Json` value representing a JSON number from an `Int`.
+   */
   final def fromInt(value: Int): Json = JNumber(JsonLong(value.toLong))
+
+  /**
+   * Create a `Json` value representing a JSON number from a `Long`.
+   */
   final def fromLong(value: Long): Json = JNumber(JsonLong(value))
 
+  /**
+   * Try to create a `Json` value representing a JSON number from a `Double`.
+   *
+   * The result is empty if the argument cannot be represented as a JSON number.
+   */
   final def fromDouble(value: Double): Option[Json] = if (isReal(value)) Some(JNumber(JsonDouble(value))) else None
+
+  /**
+   * Create a `Json` value representing a JSON number or null from a `Double`.
+   *
+   * The result is a JSON null if the argument cannot be represented as a JSON
+   * number.
+   */
   final def fromDoubleOrNull(value: Double): Json = if (isReal(value)) JNumber(JsonDouble(value)) else Null
+
+  /**
+   * Create a `Json` value representing a JSON number or string from a `Double`.
+   *
+   * The result is a JSON string if the argument cannot be represented as a JSON
+   * number.
+   */
   final def fromDoubleOrString(value: Double): Json =
     if (isReal(value)) JNumber(JsonDouble(value)) else fromString(value.toString)
 
+  /**
+   * Create a `Json` value representing a JSON number from a `BigInt`.
+   */
   final def fromBigInt(value: BigInt): Json = JNumber(JsonBiggerDecimal(BiggerDecimal.fromBigInteger(value.underlying)))
+
+  /**
+   * Create a `Json` value representing a JSON number from a `BigDecimal`.
+   */
   final def fromBigDecimal(value: BigDecimal): Json = JNumber(JsonBigDecimal(value))
 
   private[this] def isReal(value: Double): Boolean = !value.isNaN && !value.isInfinity

--- a/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -138,7 +138,7 @@ sealed abstract class JsonNumber extends Serializable {
    * This matches the behaviour of most browsers, but it is a lossy operation as you can no longer
    * distinguish between `Double.NaN` and infinity.
    */
-  final def asJsonOrNull: Json = asJson.getOrElse(Json.empty)
+  final def asJsonOrNull: Json = asJson.getOrElse(Json.Null)
 
   /**
    * Construct a JSON number if this is a valid JSON number and a JSON string otherwise.
@@ -146,7 +146,7 @@ sealed abstract class JsonNumber extends Serializable {
    * This allows a [[scala.Double]] to be losslessly encoded, but it is likely to need custom
    * handling for interoperability with other JSON systems.
    */
-  final def asJsonOrString: Json = asJson.getOrElse(Json.string(toString))
+  final def asJsonOrString: Json = asJson.getOrElse(Json.fromString(toString))
 
   /**
    * Universal equality derived from our type-safe equality.

--- a/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -105,8 +105,28 @@ final object JsonObject {
     F.foldLeft(f, empty) { case (acc, (k, v)) => acc.add(k, v) }
 
   /**
+   * Construct a [[JsonObject]] from an [[scala.collection.Iterable]] (provided for optimization).
+   */
+  final def fromIterable(fields: Iterable[(String, Json)]): JsonObject = {
+    val m = scala.collection.mutable.Map.empty[String, Json]
+    val fs = Vector.newBuilder[String]
+
+    val it = fields.iterator
+
+    while (it.hasNext) {
+      val (k, v) = it.next
+      if (!m.contains(k)) fs += k else {}
+
+      m(k) = v
+    }
+
+    MapAndVectorJsonObject(m.toMap, fs.result())
+  }
+
+  /**
    * Construct a [[JsonObject]] from an [[scala.collection.IndexedSeq]] (provided for optimization).
    */
+  @deprecated("Use fromIterable", "0.4.0")
   final def fromIndexedSeq(f: IndexedSeq[(String, Json)]): JsonObject = {
     var i = 0
     val m = scala.collection.mutable.Map.empty[String, Json]

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.`type`.TypeFactory
 import io.circe.{ Json, JsonBigDecimal, JsonObject }
 import java.util.ArrayList
 import scala.annotation.{ switch, tailrec }
+import scala.collection.JavaConverters._
 
 private[jackson] sealed trait DeserializerContext {
   def addValue(value: Json): DeserializerContext
@@ -63,7 +64,7 @@ private[jackson] final class CirceJsonDeserializer(factory: TypeFactory, klass: 
 
       case JsonTokenId.ID_END_ARRAY => parserContext match {
         case ReadingList(content) :: stack =>
-          (Some(Json.JArray(content.toArray(new Array[Json](content.size)))), stack)
+          (Some(Json.fromValues(content.asScala)), stack)
         case _ => throw new RuntimeException("We weren't reading a list, something went wrong")
       }
 
@@ -76,11 +77,7 @@ private[jackson] final class CirceJsonDeserializer(factory: TypeFactory, klass: 
 
       case JsonTokenId.ID_END_OBJECT => parserContext match {
         case ReadingMap(content) :: stack => (
-          Some(
-            Json.JObject(
-              JsonObject.fromIndexedSeq(content.toArray(new Array[(String, Json)](content.size)))
-            )
-          ),
+          Some(Json.fromFields(content.asScala)),
           stack
         )
         case _ => throw new RuntimeException("We weren't reading an object, something went wrong")

--- a/java8/src/main/scala/io/circe/java8/package.scala
+++ b/java8/src/main/scala/io/circe/java8/package.scala
@@ -15,7 +15,7 @@ package object java8 {
     }
 
   final def encodeLocalDateTime(formatter: DateTimeFormatter): Encoder[LocalDateTime] =
-    Encoder.instance(time => Json.string(time.format(formatter)))
+    Encoder.instance(time => Json.fromString(time.format(formatter)))
 
   implicit final val decodeLocalDateTimeDefault: Decoder[LocalDateTime] =
     decodeLocalDateTime(DateTimeFormatter.ISO_LOCAL_DATE_TIME)

--- a/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -6,12 +6,12 @@ import scala.collection.mutable.ArrayBuffer
 
 final object CirceSupportParser extends SupportParser[Json] {
   implicit final val facade: Facade[Json] = new Facade[Json] {
-    final def jnull(): Json = Json.Empty
+    final def jnull(): Json = Json.Null
     final def jfalse(): Json = Json.False
     final def jtrue(): Json = Json.True
     final def jnum(s: String): Json = Json.JNumber(JsonNumber.unsafeDecimal(s))
     final def jint(s: String): Json = Json.JNumber(JsonNumber.unsafeIntegral(s))
-    final def jstring(s: String): Json = Json.JString(s)
+    final def jstring(s: String): Json = Json.fromString(s)
 
     final def singleContext(): FContext[Json] = new FContext[Json] {
       private[this] final var value: Json = null

--- a/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -25,7 +25,7 @@ class LiteralMacros(val c: whitebox.Context) {
     def toJsonKey(s: String): Tree = placeHolders.get(s).flatMap(_._2).getOrElse(q"$s")
 
     def toJsonString(s: String): Tree =
-      placeHolders.get(s).map(_._1).getOrElse(q"_root_.io.circe.Json.string($s)")
+      placeHolders.get(s).map(_._1).getOrElse(q"_root_.io.circe.Json.fromString($s)")
 
     def asProxy(cls: Class[_]): Object =
       Proxy.newProxyInstance(getClass.getClassLoader, Array(cls), this)
@@ -55,7 +55,7 @@ class LiteralMacros(val c: whitebox.Context) {
     var values: List[Tree] = Nil
 
     val invokeWithoutArg: String => Object = {
-      case "finish" => q"_root_.io.circe.Json.array(..$values)"
+      case "finish" => q"_root_.io.circe.Json.arr(..$values)"
       case "isObj" => false: java.lang.Boolean
     }
 
@@ -98,7 +98,7 @@ class LiteralMacros(val c: whitebox.Context) {
   private[this] class TreeFacadeHandler(placeHolders: Map[String, (Tree, Option[Tree])])
     extends HandlerHelpers(placeHolders) {
     val invokeWithoutArg: String => Object = {
-      case "jnull" => q"_root_.io.circe.Json.empty"
+      case "jnull" => q"_root_.io.circe.Json.Null"
       case "jfalse" => q"_root_.io.circe.Json.False"
       case "jtrue" => q"_root_.io.circe.Json.True"
       case "singleContext" =>
@@ -112,12 +112,12 @@ class LiteralMacros(val c: whitebox.Context) {
     val invokeWithArg: (String, Class[_], Object) => Object = {
       case ("jnum", cls, arg: String) if cls == classOf[String] => q"""
         _root_.io.circe.Json.fromJsonNumber(
-          _root_.io.circe.JsonNumber.fromString($arg).get
+          _root_.io.circe.JsonNumber.unsafeDecimal($arg)
         )
       """
       case ("jint", cls, arg: String) if cls == classOf[String] => q"""
         _root_.io.circe.Json.fromJsonNumber(
-          _root_.io.circe.JsonNumber.fromString($arg).get
+          _root_.io.circe.JsonNumber.unsafeIntegral($arg)
         )
       """
       case ("jstring", cls, arg: String) if cls == classOf[String] => toJsonString(arg)

--- a/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/numbers/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -43,13 +43,19 @@ class BiggerDecimalSuite extends FunSuite with Checkers {
 
   test("fromBigDecimal") {
     check { (value: SBigDecimal) =>
-      val d = BiggerDecimal.fromBigDecimal(value.underlying)
+      val result = BiggerDecimal.fromBigDecimal(value.underlying)
 
       Try(new BigDecimal(value.toString)).toOption.forall { parsedValue =>
-        d.toBigDecimal.exists { roundTripped =>
+        result.toBigDecimal.exists { roundTripped =>
           roundTripped.compareTo(parsedValue) == 0
         }
       }
+    }
+  }
+
+  test("fromBigInteger") {
+    check { (value: BigInt) =>
+      BiggerDecimal.fromBigInteger(value.underlying).toBigInteger == value.underlying
     }
   }
 }

--- a/optics/src/main/scala/io/circe/optics/JsonOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonOptics.scala
@@ -16,7 +16,7 @@ import monocle.function.Plated
  * @author Julien Truffaut
  */
 trait JsonOptics extends CatsConversions {
-  final lazy val jsonBoolean: Prism[Json, Boolean] = Prism[Json, Boolean](_.asBoolean)(Json.bool)
+  final lazy val jsonBoolean: Prism[Json, Boolean] = Prism[Json, Boolean](_.asBoolean)(Json.fromBoolean)
   final lazy val jsonBigDecimal: Prism[Json, BigDecimal] =
     jsonNumber.composePrism(jsonNumberBigDecimal)
   final lazy val jsonDouble: Prism[Json, Double] = jsonNumber.composePrism(jsonNumberDouble)
@@ -25,7 +25,7 @@ trait JsonOptics extends CatsConversions {
   final lazy val jsonInt: Prism[Json, Int] = jsonNumber.composePrism(jsonNumberInt)
   final lazy val jsonShort: Prism[Json, Short] = jsonNumber.composePrism(jsonNumberShort)
   final lazy val jsonByte: Prism[Json, Byte] = jsonNumber.composePrism(jsonNumberByte)
-  final lazy val jsonString: Prism[Json, String] = Prism[Json, String](_.asString)(Json.string)
+  final lazy val jsonString: Prism[Json, String] = Prism[Json, String](_.asString)(Json.fromString)
   final lazy val jsonNumber: Prism[Json, JsonNumber] =
     Prism[Json, JsonNumber](_.asNumber)(Json.fromJsonNumber)
   final lazy val jsonObject: Prism[Json, JsonObject] =
@@ -41,9 +41,9 @@ trait JsonOptics extends CatsConversions {
         implicit val F = csApplicative(FZ)
         a.fold(
           F.pure(a),
-          b => F.pure(Json.bool(b)),
+          b => F.pure(Json.fromBoolean(b)),
           n => F.pure(Json.fromJsonNumber(n)),
-          s => F.pure(Json.string(s)),
+          s => F.pure(Json.fromString(s)),
           _.traverse(f).map(Json.fromValues),
           _.traverse(f).map(Json.fromJsonObject)
         )

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -171,7 +171,7 @@ object Boilerplate {
         -   * @group Tuple
         -   */
         -  implicit def encodeTuple$arity[${`A..N`}](implicit $instances): Encoder[${`(A..N)`}] =
-        -    Encoder.instance(t => Json.array($applied))
+        -    Encoder.instance(t => Json.arr($applied))
         |}
       """
     }

--- a/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -11,16 +11,16 @@ package object scalajs {
    * Attempt to convert a value to [[Json]].
    */
   private[this] def unsafeConvertAnyToJson(input: Any): Json = input match {
-    case s: String => Json.string(s)
-    case n: Double => Json.numberOrNull(n)
+    case s: String => Json.fromString(s)
+    case n: Double => Json.fromDoubleOrNull(n)
     case true => Json.True
     case false => Json.False
-    case null => Json.Empty
+    case null => Json.Null
     case a: js.Array[_] => Json.fromValues(a.map(unsafeConvertAnyToJson(_: Any)))
     case o: js.Object => Json.fromFields(
       o.asInstanceOf[js.Dictionary[_]].mapValues(unsafeConvertAnyToJson).toSeq
     )
-    case undefined => Json.Empty
+    case undefined => Json.Null
   }
 
   /**
@@ -56,5 +56,5 @@ package object scalajs {
     Decoder[Option[A]].map(_.fold[js.UndefOr[A]](js.undefined)(js.UndefOr.any2undefOrA))
 
   implicit final def encodeJsUndefOr[A](implicit e: Encoder[A]): Encoder[js.UndefOr[A]] =
-    Encoder.instance(_.fold(Json.empty)(e(_)))
+    Encoder.instance(_.fold(Json.Null)(e(_)))
 }

--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -10,21 +10,21 @@ trait ArbitraryInstances {
   private[this] def maxDepth: Int = 5
   private[this] def maxSize: Int = 20
 
-  private[this] def genNull: Gen[Json] = Gen.const(Json.empty)
-  private[this] def genBool: Gen[Json] = Arbitrary.arbBool.arbitrary.map(Json.bool)
+  private[this] def genNull: Gen[Json] = Gen.const(Json.Null)
+  private[this] def genBool: Gen[Json] = Arbitrary.arbBool.arbitrary.map(Json.fromBoolean)
 
   private[this] def genNumber: Gen[Json] = Gen.oneOf(
-    Arbitrary.arbLong.arbitrary.map(Json.long),
-    Arbitrary.arbDouble.arbitrary.map(Json.numberOrNull)
+    Arbitrary.arbLong.arbitrary.map(Json.fromLong),
+    Arbitrary.arbDouble.arbitrary.map(Json.fromDoubleOrNull)
   )
 
-  private[this] def genString: Gen[Json] = Arbitrary.arbString.arbitrary.map(Json.string)
+  private[this] def genString: Gen[Json] = Arbitrary.arbString.arbitrary.map(Json.fromString)
 
   private[this] def genArray(depth: Int): Gen[Json] = Gen.choose(0, maxSize).flatMap { size =>
     Gen.listOfN(
       size,
       arbitraryJsonAtDepth(depth + 1).arbitrary
-    ).map(Json.array)
+    ).map(Json.arr)
   }
 
   private[this] def genObject(depth: Int): Gen[Json] = Gen.choose(0, maxSize).flatMap { size =>
@@ -81,9 +81,7 @@ trait ArbitraryInstances {
   }
 
   implicit def shrinkJsonObject: Shrink[JsonObject] = Shrink(o =>
-    Shrink.shrinkContainer[IndexedSeq, (String, Json)].shrink(
-      o.toList.toIndexedSeq
-    ).map(JsonObject.fromIndexedSeq)
+    Shrink.shrinkContainer[List, (String, Json)].shrink(o.toList).map(JsonObject.fromIterable)
   )
 
   implicit def shrinkJson: Shrink[Json] = Shrink(

--- a/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -8,23 +8,23 @@ import org.scalacheck.{ Arbitrary, Gen }
 package object examples extends AllInstances with ArbitraryInstances with MissingInstances {
   val glossary: Json = Json.obj(
     "glossary" -> Json.obj(
-      "title" -> Json.string("example glossary"),
+      "title" -> Json.fromString("example glossary"),
       "GlossDiv" -> Json.obj(
-        "title" -> Json.string("S"),
+        "title" -> Json.fromString("S"),
         "GlossList" -> Json.obj(
           "GlossEntry" -> Json.obj(
-            "ID" -> Json.string("SGML"),
-            "SortAs" -> Json.string("SGML"),
-            "GlossTerm" -> Json.string("Standard Generalized Markup Language"),
-            "Acronym" -> Json.string("SGML"),
-            "Abbrev" -> Json.string("ISO 8879:1986"),
+            "ID" -> Json.fromString("SGML"),
+            "SortAs" -> Json.fromString("SGML"),
+            "GlossTerm" -> Json.fromString("Standard Generalized Markup Language"),
+            "Acronym" -> Json.fromString("SGML"),
+            "Abbrev" -> Json.fromString("ISO 8879:1986"),
             "GlossDef" -> Json.obj(
-              "para" -> Json.string(
+              "para" -> Json.fromString(
                 "A meta-markup language, used to create markup languages such as DocBook."
               ),
-              "GlossSeeAlso" -> Json.array(Json.string("GML"), Json.string("XML"))
+              "GlossSeeAlso" -> Json.arr(Json.fromString("GML"), Json.fromString("XML"))
             ),
-            "GlossSee" -> Json.string("markup")
+            "GlossSee" -> Json.fromString("markup")
           )
         )
       )
@@ -65,7 +65,7 @@ package examples {
   object Baz {
     implicit val decodeBaz: Decoder[Baz] = Decoder[List[String]].map(Baz(_))
     implicit val encodeBaz: Encoder[Baz] = Encoder.instance {
-      case Baz(xs) => Json.fromValues(xs.map(Json.string))
+      case Baz(xs) => Json.fromValues(xs.map(Json.fromString))
     }
   }
 

--- a/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/AccumulatingDecoderSuite.scala
@@ -9,7 +9,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("Accumulating decoder returns as many errors as invalid elements in a list") {
     check { (xs: List[Either[Int, String]]) =>
-      val json = xs.map(_.fold(Json.int, Json.string)).asJson
+      val json = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val decoded = Decoder[List[String]].accumulating(json.hcursor)
       val intElems = xs.collect { case Left(elem) => elem }
 
@@ -19,7 +19,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("replaying accumulating decoder history returns expected failures in a list") {
     check { (xs: List[Either[Int, String]]) =>
-      val json = xs.map(_.fold(Json.int, Json.string)).asJson
+      val json = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val cursor = Cursor(json).hcursor
 
       val invalidElems = xs.collect { case Left(e) => Option(e.asJson) }
@@ -31,7 +31,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("Accumulating decoder returns as many errors as invalid elements in a map") {
     check { (xs: Map[String, Either[Int, String]]) =>
-      val json = xs.map { case (k, v) => (k, v.fold(Json.int, Json.string)) }.asJson
+      val json = xs.map { case (k, v) => (k, v.fold(Json.fromInt, Json.fromString)) }.asJson
       val decoded = Decoder[Map[String, String]].accumulating(json.hcursor)
       val intElems = xs.values.collect { case Left(elem) => elem }
 
@@ -41,7 +41,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("replaying accumulating decoder history returns expected failures in a map") {
     check { (xs: Map[String, Either[Int, String]]) =>
-      val json = xs.map { case (k, v) => (k, v.fold(Json.int, Json.string)) }.asJson
+      val json = xs.map { case (k, v) => (k, v.fold(Json.fromInt, Json.fromString)) }.asJson
       val cursor = Cursor(json).hcursor
 
       val invalidElems = xs.values.collect { case Left(e) => Option(e.asJson) }.toSet
@@ -54,7 +54,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("Accumulating decoder returns as many errors as invalid elements in a set") {
     check { (xs: Set[Either[Int, String]]) =>
-      val json = xs.map(_.fold(Json.int, Json.string)).asJson
+      val json = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val decoded = Decoder[Set[String]].accumulating(json.hcursor)
       val intElems = xs.collect { case Left(elem) => elem }
 
@@ -64,7 +64,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("replaying accumulating decoder history returns expected failures in a set") {
     check { (xs: Set[Either[Int, String]]) =>
-      val json = xs.map(_.fold(Json.int, Json.string)).asJson
+      val json = xs.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val cursor = Cursor(json).hcursor
 
       val invalidElems = xs.collect { case Left(e) => Option(e.asJson) }
@@ -78,9 +78,9 @@ class AccumulatingDecoderSuite extends CirceSuite {
   test("Accumulating decoder returns as many errors as invalid elements in a tuple") {
     check { (xs: (Either[Int, String], Either[Int, String], Either[Int, String])) =>
       val json = (
-        xs._1.fold(Json.int, Json.string),
-        xs._2.fold(Json.int, Json.string),
-        xs._3.fold(Json.int, Json.string)
+        xs._1.fold(Json.fromInt, Json.fromString),
+        xs._2.fold(Json.fromInt, Json.fromString),
+        xs._3.fold(Json.fromInt, Json.fromString)
         ).asJson
       val decoded = Decoder[(String, String, String)].accumulating(json.hcursor)
       val intElems = List(xs._1, xs._2, xs._3).collect { case Left(elem) => elem }
@@ -92,9 +92,9 @@ class AccumulatingDecoderSuite extends CirceSuite {
   test("replaying accumulating decoder history returns expected failures in a tuple") {
     check { (xs: (Either[Int, String], Either[Int, String], Either[Int, String])) =>
       val json = (
-        xs._1.fold(Json.int, Json.string),
-        xs._2.fold(Json.int, Json.string),
-        xs._3.fold(Json.int, Json.string)
+        xs._1.fold(Json.fromInt, Json.fromString),
+        xs._2.fold(Json.fromInt, Json.fromString),
+        xs._3.fold(Json.fromInt, Json.fromString)
         ).asJson
       val cursor = Cursor(json).hcursor
 
@@ -111,7 +111,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("Accumulating decoder returns as many errors as invalid elements in a non-empty list") {
     check { (nel: NonEmptyList[Either[Int, String]]) =>
-      val json = nel.map(_.fold(Json.int, Json.string)).asJson
+      val json = nel.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val decoded = Decoder[NonEmptyList[String]].accumulating(json.hcursor)
       val intElems = nel.toList.collect { case Left(elem) => elem }
 
@@ -121,7 +121,7 @@ class AccumulatingDecoderSuite extends CirceSuite {
 
   test("replaying accumulating decoder history returns expected failures in a non-empty list") {
     check { (nel: NonEmptyList[Either[Int, String]]) =>
-      val json = nel.map(_.fold(Json.int, Json.string)).asJson
+      val json = nel.map(_.fold(Json.fromInt, Json.fromString)).asJson
       val cursor = Cursor(json).hcursor
 
       val invalidElems = nel.toList.collect { case Left(e) => Option(e.asJson) }

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -53,7 +53,7 @@ class StdLibCodecSuite extends CirceSuite {
   test("Tuples should be encoded as JSON arrays") {
     check { (t: (Int, String, Char)) =>
       val json = Encoder[(Int, String, Char)].apply(t)
-      val target = Json.array(Json.int(t._1), Json.string(t._2), Encoder[Char].apply(t._3))
+      val target = Json.arr(Json.fromInt(t._1), Json.fromString(t._2), Encoder[Char].apply(t._3))
 
       json === target && json.as[(Int, String, Char)] === Xor.right(t)
     }
@@ -61,19 +61,19 @@ class StdLibCodecSuite extends CirceSuite {
 
   test("Decoding a JSON array without enough elements into a tuple should fail") {
     check { (i: Int, s: String) =>
-      Json.array(Json.int(i), Json.string(s)).as[(Int, String, Double)].isLeft
+      Json.arr(Json.fromInt(i), Json.fromString(s)).as[(Int, String, Double)].isLeft
     }
   }
 
   test("Decoding a JSON array with too many elements into a tuple should fail") {
     check { (i: Int, s: String, d: Double) =>
-      Json.array(Json.int(i), Json.string(s), Json.numberOrNull(d)).as[(Int, String)].isLeft
+      Json.arr(Json.fromInt(i), Json.fromString(s), Json.fromDoubleOrNull(d)).as[(Int, String)].isLeft
     }
   }
 
   test("Decoding a JSON array with many elements into a sequence should not stack overflow") {
     val size = 10000
-    val jsonArr = Json.array(Seq.fill(size)(Json.int(1)): _*)
+    val jsonArr = Json.arr(Seq.fill(size)(Json.fromInt(1)): _*)
 
     val maybeList = jsonArr.as[List[Int]]
     assert(maybeList.isRight)
@@ -93,7 +93,7 @@ class StdLibCodecSuite extends CirceSuite {
       }
     }
 
-    val jsonArr = Json.array(Json.int(1), Json.string("foo"), Json.int(0))
+    val jsonArr = Json.arr(Json.fromInt(1), Json.fromString("foo"), Json.fromInt(0))
     val result = jsonArr.as[List[Bomb]]
 
     assert(result.isLeft)
@@ -121,10 +121,10 @@ class DisjunctionCodecSuite extends CirceSuite {
 }
 
 class DecodingFailureSuite extends CirceSuite {
-  val n = Json.int(10)
+  val n = Json.fromInt(10)
   val b = Json.True
-  val s = Json.string("foo")
-  val l = Json.array(s)
+  val s = Json.fromString("foo")
+  val l = Json.arr(s)
   val o = Json.obj("foo" -> n)
 
   val nd = Decoder[Int]

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -47,7 +47,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Byte] fails on out-of-range values (#83)") {
     check { (l: Long) =>
-      val json = Json.long(l)
+      val json = Json.fromLong(l)
       val result = Decoder[Byte].apply(json.hcursor)
 
       if (l.toByte.toLong == l) result === Xor.right(l.toByte) else result.isEmpty
@@ -56,7 +56,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Short] fails on out-of-range values (#83)") {
     check { (l: Long) =>
-      val json = Json.long(l)
+      val json = Json.fromLong(l)
       val result = Decoder[Short].apply(json.hcursor)
 
       if (l.toShort.toLong == l) result === Xor.right(l.toShort) else result.isEmpty
@@ -65,7 +65,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Int] fails on out-of-range values (#83)") {
     check { (l: Long) =>
-      val json = Json.long(l)
+      val json = Json.fromLong(l)
       val result = Decoder[Int].apply(json.hcursor)
 
       if (l.toInt.toLong == l) result === Xor.right(l.toInt) else result.isEmpty
@@ -74,7 +74,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Long] fails on out-of-range values (#83)") {
     check { (i: BigInt) =>
-      val json = Json.bigDecimal(BigDecimal(i))
+      val json = Json.fromBigDecimal(BigDecimal(i))
       val result = Decoder[Long].apply(json.hcursor)
 
       if (BigInt(i.toLong) == i) result === Xor.right(i.toLong) else result.isEmpty
@@ -83,7 +83,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Byte] fails on non-whole values (#83)") {
     check { (d: Double) =>
-      val json = Json.numberOrNull(d)
+      val json = Json.fromDoubleOrNull(d)
       val result = Decoder[Byte].apply(json.hcursor)
 
       d.isWhole || result.isEmpty
@@ -92,7 +92,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Short] fails on non-whole values (#83)") {
     check { (d: Double) =>
-      val json = Json.numberOrNull(d)
+      val json = Json.fromDoubleOrNull(d)
       val result = Decoder[Short].apply(json.hcursor)
 
       d.isWhole || result.isEmpty
@@ -101,7 +101,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Int] fails on non-whole values (#83)") {
     check { (d: Double) =>
-      val json = Json.numberOrNull(d)
+      val json = Json.fromDoubleOrNull(d)
       val result = Decoder[Int].apply(json.hcursor)
 
       d.isWhole || result.isEmpty
@@ -110,7 +110,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
   test("Decoder[Long] fails on non-whole values (#83)") {
     check { (d: Double) =>
-      val json = Json.numberOrNull(d)
+      val json = Json.fromDoubleOrNull(d)
       val result = Decoder[Long].apply(json.hcursor)
 
       d.isWhole || result.isEmpty

--- a/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/JsonNumberSuite.scala
@@ -10,9 +10,9 @@ class JsonNumberSuite extends CirceSuite {
     }
   }
 
-  test("fromString should match Json.number") {
+  test("fromString should match Json.fromDouble") {
     check { (d: Double) =>
-      Json.number(d).flatMap(_.asNumber) === JsonNumber.fromString(d.toString)
+      Json.fromDouble(d).flatMap(_.asNumber) === JsonNumber.fromString(d.toString)
     }
   }
 
@@ -91,14 +91,14 @@ class JsonNumberSuite extends CirceSuite {
   }
 
   test("number is empty on Double.NaN") {
-    assert(Json.number(Double.NaN) === None)
+    assert(Json.fromDouble(Double.NaN) === None)
   }
 
   test("number is empty on Double.PositiveInfinity") {
-    assert(Json.number(Double.PositiveInfinity) === None)
+    assert(Json.fromDouble(Double.PositiveInfinity) === None)
   }
 
   test("number is empty on Double.NegativeInfinity") {
-    assert(Json.number(Double.NegativeInfinity) === None)
+    assert(Json.fromDouble(Double.NegativeInfinity) === None)
   }
 }

--- a/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -81,8 +81,8 @@ class AutoDerivedSuite extends CirceSuite {
   test("Decoder[Int => Qux[String]]") {
     check { (i: Int, s: String, j: Int) =>
       Json.obj(
-        "a" -> Json.string(s),
-        "j" -> Json.int(j)
+        "a" -> Json.fromString(s),
+        "j" -> Json.fromInt(j)
       ).as[Int => Qux[String]].map(_(i)) === Xor.right(Qux(i, s, j))
     }
   }
@@ -90,8 +90,8 @@ class AutoDerivedSuite extends CirceSuite {
   test("Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]") {
     check { (i: Int, s: String, j: Int) =>
       Json.obj(
-        "i" -> Json.int(i),
-        "a" -> Json.string(s)
+        "i" -> Json.fromInt(i),
+        "a" -> Json.fromString(s)
       ).as[FieldType[Witness.`'j`.T, Int] => Qux[String]].map(
          _(field(j))
       ) === Xor.right(Qux(i, s, j))
@@ -116,13 +116,13 @@ class AutoDerivedSuite extends CirceSuite {
     check { (is: List[Int]) =>
       val json = Encoder[List[Int]].apply(is)
 
-      json === Json.fromValues(is.map(Json.int)) && json.as[List[Int]] === Xor.right(is)
+      json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Xor.right(is)
     }
   }
 
   test("Generic decoders should not interfere with defined decoders") {
     check { (xs: List[String]) =>
-      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.string)))
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
 
       Decoder[Foo].apply(json.hcursor) === Xor.right(Baz(xs): Foo)
     }
@@ -130,14 +130,14 @@ class AutoDerivedSuite extends CirceSuite {
 
   test("Generic encoders should not interfere with defined encoders") {
     check { (xs: List[String]) =>
-      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.string)))
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
 
       Encoder[Foo].apply(Baz(xs): Foo) === json
     }
   }
 
   test("Decoding with Decoder[CNil] should fail") {
-    assert(Json.empty.as[CNil].isLeft)
+    assert(Json.Null.as[CNil].isLeft)
   }
 
   test("Encoding with Encoder[CNil] should throw an exception") {

--- a/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -83,8 +83,8 @@ class SemiautoDerivedSuite extends CirceSuite {
   test("Decoder[Int => Qux[String]]") {
     check { (i: Int, s: String, j: Int) =>
       Json.obj(
-        "a" -> Json.string(s),
-        "j" -> Json.int(j)
+        "a" -> Json.fromString(s),
+        "j" -> Json.fromInt(j)
       ).as[Int => Qux[String]].map(_(i)) === Xor.right(Qux(i, s, j))
     }
   }
@@ -92,8 +92,8 @@ class SemiautoDerivedSuite extends CirceSuite {
   test("Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]") {
     check { (i: Int, s: String, j: Int) =>
       Json.obj(
-        "i" -> Json.int(i),
-        "a" -> Json.string(s)
+        "i" -> Json.fromInt(i),
+        "a" -> Json.fromString(s)
       ).as[FieldType[Witness.`'j`.T, Int] => Qux[String]].map(
         _(field(j))
       ) === Xor.right(Qux(i, s, j))
@@ -118,7 +118,7 @@ class SemiautoDerivedSuite extends CirceSuite {
     check { (is: List[Int]) =>
       val json = Encoder[List[Int]].apply(is)
 
-      json === Json.fromValues(is.map(Json.int)) && json.as[List[Int]] === Xor.right(is)
+      json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Xor.right(is)
     }
   }
 

--- a/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/syntax/SyntaxSuite.scala
@@ -6,7 +6,7 @@ import io.circe.tests.CirceSuite
 class SyntaxSuite extends CirceSuite {
   test("EncodeOps.asJson") {
     check { (s: String) =>
-      s.asJson === Json.string(s)
+      s.asJson === Json.fromString(s)
     }
   }
 }


### PR DESCRIPTION
This is a fairly large but superficial change that brings some consistency to the `Json` API. Highlights:

* The `number*` methods that take a `Double` are now `fromDouble*`. It's not like `Double` is somehow more "number-y" than any other numeric types.
* `Json.int` is now `Json.fromInt`, in part because `int` is a keyword in Java.
* More generally, conversion methods are now `fromWhatever`, where `Whatever` is the full name of the type. For example `Json.bool` is now `Json.fromBoolean`.
* `Json.obj` was abbreviated (since `object` is a Scala keyword) but `Json.array` was not. They're now both abbreviated for the sake of consistency.
* I've replaced `JsonObject.fromIndexedSeq` with `JsonObject.fromIterable` since there was no real advantage to requiring an `IndexedSeq` there.
* I've added a `Json.fromBigInt` method.
* I've used public methods instead of package private constructors wherever possible.

No existing code will break, although anyone who's using `Json` methods is likely to see some deprecations. All of these deprecated methods will probably disappear in 0.5, but will definitely be available in the 0.4 releases.
