### PR TITLE
Simplify JsonNumber

### DIFF
--- a/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
@@ -14,11 +14,6 @@ import monocle.Prism
  * @author Travis Brown
  */
 trait JsonNumberOptics {
-  final lazy val jsonNumberDouble: Prism[JsonNumber, Double] = Prism[JsonNumber, Double]{ n =>
-    val d = n.toDouble
-    if (JsonNumber.eqJsonNumber.eqv(JsonDouble(d), n)) Some(d) else None
-  }(JsonDouble(_))
-
   final lazy val jsonNumberBigInt: Prism[JsonNumber, BigInt] = Prism[JsonNumber, BigInt](jn =>
     if (JsonNumberOptics.isNegativeZero(jn)) None else jn.toBigInt
   )(b => JsonBigDecimal(BigDecimal(b, MathContext.UNLIMITED)))

--- a/optics/src/main/scala/io/circe/optics/JsonOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonOptics.scala
@@ -17,21 +17,18 @@ import monocle.function.Plated
  */
 trait JsonOptics extends CatsConversions {
   final lazy val jsonBoolean: Prism[Json, Boolean] = Prism[Json, Boolean](_.asBoolean)(Json.fromBoolean)
-  final lazy val jsonBigDecimal: Prism[Json, BigDecimal] =
-    jsonNumber.composePrism(jsonNumberBigDecimal)
-  final lazy val jsonDouble: Prism[Json, Double] = jsonNumber.composePrism(jsonNumberDouble)
+  final lazy val jsonBigDecimal: Prism[Json, BigDecimal] = jsonNumber.composePrism(jsonNumberBigDecimal)
   final lazy val jsonBigInt: Prism[Json, BigInt] = jsonNumber.composePrism(jsonNumberBigInt)
   final lazy val jsonLong: Prism[Json, Long] = jsonNumber.composePrism(jsonNumberLong)
   final lazy val jsonInt: Prism[Json, Int] = jsonNumber.composePrism(jsonNumberInt)
   final lazy val jsonShort: Prism[Json, Short] = jsonNumber.composePrism(jsonNumberShort)
   final lazy val jsonByte: Prism[Json, Byte] = jsonNumber.composePrism(jsonNumberByte)
   final lazy val jsonString: Prism[Json, String] = Prism[Json, String](_.asString)(Json.fromString)
-  final lazy val jsonNumber: Prism[Json, JsonNumber] =
-    Prism[Json, JsonNumber](_.asNumber)(Json.fromJsonNumber)
-  final lazy val jsonObject: Prism[Json, JsonObject] =
-    Prism[Json, JsonObject](_.asObject)(Json.fromJsonObject)
-  final lazy val jsonArray: Prism[Json, List[Json]] =
-    Prism[Json, List[Json]](_.asArray)(Json.fromValues)
+  final lazy val jsonNumber: Prism[Json, JsonNumber] = Prism[Json, JsonNumber](_.asNumber)(Json.fromJsonNumber)
+  final lazy val jsonObject: Prism[Json, JsonObject] = Prism[Json, JsonObject](_.asObject)(Json.fromJsonObject)
+  final lazy val jsonArray: Prism[Json, List[Json]] = Prism[Json, List[Json]](_.asArray)(Json.fromValues)
+  final lazy val jsonDouble: Prism[Json, Double] =
+    Prism[Json, Double](_.asNumber.map(_.toDouble))(Json.fromDoubleOrNull)
 
   implicit final lazy val jsonPlated: Plated[Json] = new Plated[Json] {
     val plate: Traversal[Json, Json] = new Traversal[Json, Json] {

--- a/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -36,7 +36,6 @@ class OpticsSuite extends CirceSuite {
   checkAll("Json to List[Json]", PrismTests(jsonArray))
 
   checkAll("JsonNumber to BigDecimal", PrismTests(jsonNumberBigDecimal))
-  checkAll("JsonNumber to Double", PrismTests(jsonNumberDouble))
   checkAll("JsonNumber to BigInt", PrismTests(jsonNumberBigInt))
   checkAll("JsonNumber to Long", PrismTests(jsonNumberLong))
   checkAll("JsonNumber to Int", PrismTests(jsonNumberInt))

--- a/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -100,7 +100,7 @@ trait ArbitraryInstances {
       Arbitrary.arbitrary[JsonNumberString].map(jns => JsonNumber.unsafeDecimal(jns.value)),
       Arbitrary.arbitrary[BigDecimal].map(JsonBigDecimal(_)),
       Arbitrary.arbitrary[Long].map(JsonLong(_)),
-      Arbitrary.arbitrary[Double].map(JsonDouble(_))
+      Arbitrary.arbitrary[Double].map(d => if (d.isNaN || d.isInfinity) JsonDouble(0.0) else JsonDouble(d))
     )
   )
 


### PR DESCRIPTION
This is a follow-up to #210 and I'll rebase it once #210 gets merged.

The basic idea is that we control the `JsonNumber` constructors, and we can be sure that `JsonDouble` never gets called with a `NaN` or infinite `Double` value, so there's no point in checking for these conditions.

This does mean that we can no longer have a prism in circe-optics from `JsonNumber` to `Double`, but `Json` to `Double` is fine, so I'm totally okay with that.