### PR TITLE
Fix #217

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -527,7 +527,9 @@ final object Decoder extends TupleDecoders with LowPriorityDecoders {
           case Xor.Left(df) if df.history.isEmpty => rightNone
           case Xor.Left(df) => Xor.left(df)
         }
-      } else rightNone
+      } else if (c.any.focus.isObject) {
+        rightNone
+      } else Xor.left(DecodingFailure("[A]Option[A]", c.history))
     )
 
   /**


### PR DESCRIPTION
This is a quick draft of a fix for #217, which reports a bug (inherited from and also still present in Argonaut) where case classes with all optional fields can be successfully decoded from a JSON `null`:

```scala
scala> import io.circe._, io.circe.jawn._
import io.circe._
import io.circe.jawn._

scala> case class Foo(o: Option[String])
defined class Foo

scala> implicit val decodeFoo: Decoder[Foo] = Decoder.instance(c =>
     |   c.downField("o").as[Option[String]].map(Foo(_))
     | )
decodeFoo: io.circe.Decoder[Foo] = io.circe.Decoder$$anon$8@5f7b1ec9

scala> decode[Foo]("null")
res0: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(None))
```

If you don't have any case classes with all optional members, or you don't mind that they can be decoded from a JSON `null` (as opposed to at least a `{}`), you're fine.

At a glance I think this is related to the issue reported in [this recent Argonaut pull request](https://github.com/argonaut-io/argonaut/pull/213/files), although the changes there don't fix this part of the problem:

```scala
scala> import argonaut._, Argonaut._
import argonaut._
import Argonaut._

scala> case class Foo(o: Option[String])
defined class Foo

scala> implicit val codec = jdecode1L[Option[String], Foo](Foo(_))("o")
codec: argonaut.DecodeJson[Foo] = argonaut.DecodeJson$$anon$4@4e71965f

scala> Parse.decodeOption[Foo]("null")
res0: Option[Foo] = Some(Foo(None))
```

This PR currently works in our simple example:

```scala
scala> import io.circe._, io.circe.jawn._
import io.circe._
import io.circe.jawn._

scala> case class Foo(o: Option[String])
defined class Foo

scala> implicit val decodeFoo: Decoder[Foo] = Decoder.instance(c =>
     |   c.downField("o").as[Option[String]].map(Foo(_))
     | )
decodeFoo: io.circe.Decoder[Foo] = io.circe.Decoder$$anon$8@251634

scala> decode[Foo]("null")
res0: cats.data.Xor[io.circe.Error,Foo] = Left(io.circe.DecodingFailure: [A]Option[A]: El(DownField(o),false))
```

But it's only a sketch (I'm at the Typelevel Summit today and haven't been able to take a closer look) and won't work in more interesting cases.

I'll wrap it up and publish an 0.3.1 as soon as possible (probably this evening or tomorrow).
