### PR TITLE
Remove unused imports

### DIFF
--- a/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import algebra.{ Eq, Monoid }
+import algebra.Eq
 import cats.Show
 import cats.std.list._
 import io.circe.cursor.{ CArray, CJson, CObject, CursorOperations }

--- a/core/shared/src/main/scala/io/circe/GenericCursor.scala
+++ b/core/shared/src/main/scala/io/circe/GenericCursor.scala
@@ -1,7 +1,6 @@
 package io.circe
 
 import cats.Functor
-import cats.data.Xor
 
 /**
  * A zipper that represents a position in a JSON document and supports navigation and modification.

--- a/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -1,7 +1,7 @@
 package io.circe
 
 import algebra.Eq
-import cats.data.{ NonEmptyList, Validated, Xor }
+import cats.data.Xor
 import io.circe.cursor.HCursorOperations
 import scala.annotation.tailrec
 

--- a/core/shared/src/main/scala/io/circe/Json.scala
+++ b/core/shared/src/main/scala/io/circe/Json.scala
@@ -2,7 +2,6 @@ package io.circe
 
 import algebra.Eq
 import cats.Show
-import cats.data.Xor
 import io.circe.numbers.BiggerDecimal
 
 /**

--- a/core/shared/src/main/scala/io/circe/JsonNumber.scala
+++ b/core/shared/src/main/scala/io/circe/JsonNumber.scala
@@ -2,8 +2,6 @@ package io.circe
 
 import algebra.Eq
 import io.circe.numbers.{ BiggerDecimal, NumberParsing }
-import java.math.{ BigDecimal => JBigDecimal, MathContext }
-import scala.util.matching.Regex
 
 /**
  * A JSON number with optimization by cases.

--- a/core/shared/src/main/scala/io/circe/cursor/ACursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/ACursorOperations.scala
@@ -1,7 +1,6 @@
 package io.circe.cursor
 
 import cats.Applicative
-import cats.data.Xor
 import io.circe._
 
 /**

--- a/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/CursorOperations.scala
@@ -1,8 +1,7 @@
 package io.circe.cursor
 
 import cats.{ Functor, Id }
-import cats.data.Xor
-import io.circe.{ ACursor, Cursor, Decoder, DecodingFailure, GenericCursor, HistoryOp, Json }
+import io.circe.{ ACursor, Cursor, Decoder, GenericCursor, HistoryOp, Json }
 import scala.annotation.tailrec
 
 /**

--- a/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
+++ b/core/shared/src/main/scala/io/circe/cursor/HCursorOperations.scala
@@ -1,7 +1,6 @@
 package io.circe.cursor
 
 import cats.{ Functor, Id }
-import cats.data.Xor
 import io.circe._
 
 /**

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,7 +1,6 @@
 package io.circe.generic
 
 import export.reexports
-import io.circe.{ Decoder, Encoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -1,6 +1,6 @@
 package io.circe.generic
 
-import io.circe.{ Decoder, HCursor, JsonObject, ObjectEncoder }
+import io.circe.{ Decoder, ObjectEncoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.util.PatchWithOptions

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonDeserializer.scala
@@ -1,10 +1,9 @@
 package io.circe.jackson
 
-import cats.data.Xor
 import com.fasterxml.jackson.core.{ JsonParser, JsonTokenId }
 import com.fasterxml.jackson.databind.{ DeserializationContext, JsonDeserializer }
 import com.fasterxml.jackson.databind.`type`.TypeFactory
-import io.circe.{ Json, JsonBigDecimal, JsonObject }
+import io.circe.{ Json, JsonBigDecimal }
 import java.util.ArrayList
 import scala.annotation.{ switch, tailrec }
 import scala.collection.JavaConverters._

--- a/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
+++ b/jackson/src/main/scala/io/circe/jackson/CirceJsonModule.scala
@@ -1,12 +1,10 @@
 package io.circe.jackson
 
-import cats.data.Xor
 import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.databind.{
   BeanDescription,
   DeserializationConfig,
   JavaType,
-  JsonDeserializer,
   JsonSerializer,
   SerializationConfig
 }

--- a/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -1,7 +1,7 @@
 package io.circe.literal
 
 import cats.data.Xor
-import io.circe.{ Json, Parser }
+import io.circe.Json
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 import java.util.UUID
 import macrocompat.bundle

--- a/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonNumberOptics.scala
@@ -1,6 +1,6 @@
 package io.circe.optics
 
-import io.circe.{ JsonBigDecimal, JsonDouble, JsonLong, JsonNumber }
+import io.circe.{ JsonBigDecimal, JsonLong, JsonNumber }
 import java.math.MathContext
 import monocle.Prism
 

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -117,7 +117,7 @@ object Boilerplate {
         |package io.circe
         |
         |import cats.{ Applicative, Semigroup, SemigroupK }
-        |import cats.data.{ NonEmptyList, Validated, Xor }
+        |import cats.data.{ NonEmptyList, Xor }
         |import cats.std.ListInstances
         |
         |private[circe] trait TupleDecoders extends ListInstances {

--- a/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -3,7 +3,7 @@ package io.circe
 import cats.data.Xor
 import io.circe.Json._
 import scala.scalajs.js
-import scala.scalajs.js.{ undefined, JavaScriptException, SyntaxError }
+import scala.scalajs.js.undefined
 import scala.scalajs.js.JSConverters.{ JSRichGenMap, JSRichGenTraversableOnce }
 
 package object scalajs {

--- a/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
+++ b/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
@@ -7,7 +7,7 @@ import cats.std.vector._
 import cats.syntax.traverse._
 import io.circe.{ Json, ParsingFailure }
 import io.circe.jawn.CirceSupportParser
-import io.iteratee.{ Enumeratee, Iteratee }
+import io.iteratee.Enumeratee
 import io.iteratee.internal.Step
 
 private[streaming] abstract class ParsingEnumeratee[F[_], S](implicit F: MonadError[F, Throwable])

--- a/tests/shared/src/main/scala/io/circe/tests/CodecTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/CodecTests.scala
@@ -4,7 +4,7 @@ import algebra.Eq
 import cats.data.Xor
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.{ Decoder, Encoder, Json }
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
 import org.typelevel.discipline.Laws

--- a/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
@@ -1,8 +1,7 @@
 package io.circe.tests
 
 import algebra.Eq
-import cats.data.{ NonEmptyList, Validated, Xor }
-import io.circe.{ Cursor, GenericCursor, Json }
+import io.circe.{ GenericCursor, Json }
 import io.circe.syntax._
 
 abstract class CursorSuite[C <: GenericCursor[C]](implicit

--- a/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
@@ -1,6 +1,5 @@
 package io.circe.tests
 
-import algebra.Eq
 import cats.data.Xor
 import cats.laws._
 import cats.laws.discipline._

--- a/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
@@ -1,7 +1,6 @@
 package io.circe.tests
 
 import algebra.Eq
-import cats.data.Xor
 import cats.laws._
 import cats.laws.discipline._
 import cats.std.option._


### PR DESCRIPTION
I feel like maybe the unused import checking got better in 2.11.8 because I could swear most of these warnings are new.