### PR TITLE
Clearer failure behavior for optional decoders

### DIFF
--- a/core/shared/src/main/scala/io/circe/CursorOp.scala
+++ b/core/shared/src/main/scala/io/circe/CursorOp.scala
@@ -3,34 +3,60 @@ package io.circe
 import algebra.Eq
 import cats.Show
 
-sealed abstract class CursorOp extends Product with Serializable
+sealed abstract class CursorOp extends Product with Serializable {
+  /**
+   * Does this operation require the current focus (not context) to be an
+   * object?
+   */
+  def requiresObject: Boolean
+
+  /**
+   * Does this operation require the current focus (not context) to be an array?
+   */
+  def requiresArray: Boolean
+}
 
 final object CursorOp {
-  final case object MoveLeft extends CursorOp
-  final case object MoveRight extends CursorOp
-  final case object MoveFirst extends CursorOp
-  final case object MoveLast extends CursorOp
-  final case object MoveUp extends CursorOp
-  final case class LeftN(n: Int) extends CursorOp
-  final case class RightN(n: Int) extends CursorOp
-  final case class LeftAt(p: Json => Boolean) extends CursorOp
-  final case class RightAt(p: Json => Boolean) extends CursorOp
-  final case class Find(p: Json => Boolean) extends CursorOp
-  final case class Field(k: String) extends CursorOp
-  final case class DownField(k: String) extends CursorOp
-  final case object DownArray extends CursorOp
-  final case class DownAt(p: Json => Boolean) extends CursorOp
-  final case class DownN(n: Int) extends CursorOp
-  final case object DeleteGoParent extends CursorOp
-  final case object DeleteGoLeft extends CursorOp
-  final case object DeleteGoRight extends CursorOp
-  final case object DeleteGoFirst extends CursorOp
-  final case object DeleteGoLast extends CursorOp
-  final case class DeleteGoField(k: String) extends CursorOp
-  final case object DeleteLefts extends CursorOp
-  final case object DeleteRights extends CursorOp
-  final case class SetLefts(js: List[Json]) extends CursorOp
-  final case class SetRights(js: List[Json]) extends CursorOp
+  abstract sealed class ObjectOp extends CursorOp {
+    final def requiresObject: Boolean = true
+    final def requiresArray: Boolean = false
+  }
+
+  abstract sealed class ArrayOp extends CursorOp {
+    final def requiresObject: Boolean = false
+    final def requiresArray: Boolean = true
+  }
+
+  abstract sealed class UnconstrainedOp extends CursorOp {
+    final def requiresObject: Boolean = false
+    final def requiresArray: Boolean = false
+  }
+
+  final case object MoveLeft extends UnconstrainedOp
+  final case object MoveRight extends UnconstrainedOp
+  final case object MoveFirst extends UnconstrainedOp
+  final case object MoveLast extends UnconstrainedOp
+  final case object MoveUp extends UnconstrainedOp
+  final case class LeftN(n: Int) extends UnconstrainedOp
+  final case class RightN(n: Int) extends UnconstrainedOp
+  final case class LeftAt(p: Json => Boolean) extends UnconstrainedOp
+  final case class RightAt(p: Json => Boolean) extends UnconstrainedOp
+  final case class Find(p: Json => Boolean) extends UnconstrainedOp
+  final case class Field(k: String) extends UnconstrainedOp
+  final case class DownField(k: String) extends ObjectOp
+  final case object DownArray extends ArrayOp
+  final case class DownAt(p: Json => Boolean) extends ArrayOp
+  final case class DownN(n: Int) extends ArrayOp
+  final case object DeleteGoParent extends UnconstrainedOp
+  final case object DeleteGoLeft extends UnconstrainedOp
+  final case object DeleteGoRight extends UnconstrainedOp
+  final case object DeleteGoFirst extends UnconstrainedOp
+  final case object DeleteGoLast extends UnconstrainedOp
+  final case class DeleteGoField(k: String) extends UnconstrainedOp
+  final case object DeleteLefts extends UnconstrainedOp
+  final case object DeleteRights extends UnconstrainedOp
+  final case class SetLefts(js: List[Json]) extends UnconstrainedOp
+  final case class SetRights(js: List[Json]) extends UnconstrainedOp
 
   implicit final val showCursorOp: Show[CursorOp] = Show.show {
     case MoveLeft => "<-"

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -527,7 +527,9 @@ final object Decoder extends TupleDecoders with LowPriorityDecoders {
           case Xor.Left(df) if df.history.isEmpty => rightNone
           case Xor.Left(df) => Xor.left(df)
         }
-      } else rightNone
+      } else if (!c.history.takeWhile(_.failed).exists(_.incorrectFocus)) rightNone else {
+        Xor.left(DecodingFailure("[A]Option[A]", c.history))
+      }
     )
 
   /**

--- a/core/shared/src/main/scala/io/circe/HistoryOp.scala
+++ b/core/shared/src/main/scala/io/circe/HistoryOp.scala
@@ -8,23 +8,29 @@ sealed abstract class HistoryOp extends Product with Serializable {
   def isNotReattempt: Boolean
   def succeeded: Boolean
   def failed: Boolean
+  def incorrectFocus: Boolean
   def op: Option[CursorOp]
 }
 
 final object HistoryOp {
-  final def ok(o: CursorOp): HistoryOp = El(o, succeeded = true)
-  final def fail(o: CursorOp): HistoryOp = El(o, succeeded = false)
+  final def ok(o: CursorOp): HistoryOp = El(o, true, false)
+  final def fail(o: CursorOp, incorrectContext: Boolean): HistoryOp = El(o, false, incorrectContext)
   final def reattempt: HistoryOp = Reattempt
 
   private[this] final case object Reattempt extends HistoryOp {
-    final def isReattempt: Boolean = true
-    final def isNotReattempt: Boolean = false
-    final def succeeded: Boolean = false
-    final def failed: Boolean = false
-    final def op: Option[CursorOp] = None
+    final val isReattempt: Boolean = true
+    final val isNotReattempt: Boolean = false
+    final val succeeded: Boolean = false
+    final val failed: Boolean = false
+    final val incorrectFocus: Boolean = false
+    final val op: Option[CursorOp] = None
   }
 
-  private[this] final case class El(o: CursorOp, succeeded: Boolean) extends HistoryOp {
+  private[this] final case class El(
+    o: CursorOp,
+    succeeded: Boolean,
+    incorrectFocus: Boolean
+  ) extends HistoryOp {
     final def isReattempt: Boolean = false
     final def isNotReattempt: Boolean = true
     final def failed: Boolean = !succeeded
@@ -33,13 +39,13 @@ final object HistoryOp {
 
   implicit final val eqCursorOp: Eq[HistoryOp] = Eq.instance {
     case (Reattempt, Reattempt) => true
-    case (El(o1, s1), El(o2, s2)) => Eq[CursorOp].eqv(o1, o2) && s1 == s2
+    case (El(o1, s1, c1), El(o2, s2, c2)) => Eq[CursorOp].eqv(o1, o2) && s1 == s2 && c1 == c2
     case (_, _) => false
   }
 
   implicit final val showCursorOp: Show[HistoryOp] = Show.show {
     case Reattempt => ".?."
-    case El(o, s) =>
+    case El(o, s, _) =>
       val shownOp = Show[CursorOp].show(o)
       if (s) shownOp else s"*.$shownOp"
   }

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -45,6 +45,72 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
     }
   }
 
+  test("Optional object field decoders fail appropriately") {
+    val decoder: Decoder[Option[String]] = Decoder.instance(
+      _.downField("").downField("").as[Option[String]]
+    )
+
+    check { (json: Json) =>
+      val result = decoder.apply(json.hcursor)
+
+      json.asObject match {
+        // The top-level value isn't an object, so we should fail.
+        case None => result.isLeft
+        case Some(o1) => o1("") match {
+          // The top-level object doesn't contain a "" key, so we should succeed emptily.
+          case None => result === Xor.Right(None)
+          case Some(j2) => j2.asObject match {
+            // The second-level value isn't an object, so we should fail.
+            case None => result.isLeft
+            case Some(o2) => o2("") match {
+              // The second-level object doesn't contain a "" key, so we should succeed emptily.
+              case None => result === Xor.Right(None)
+              case Some(j3) => j3.asString match {
+                // The third-level value isn't a string, so we should fail.
+                case None => result.isLeft
+                // The third-level value is a string, so we should have decoded it.
+                case Some(s3) => result === Xor.Right(Some(s3))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("Optional array position decoders fail appropriately") {
+    val decoder: Decoder[Option[String]] = Decoder.instance(
+      _.downN(0).downN(1).as[Option[String]]
+    )
+
+    check { (json: Json) =>
+      val result = decoder.apply(json.hcursor)
+
+      json.asArray match {
+        // The top-level value isn't an array, so we should fail.
+        case None => result.isLeft
+        case Some(a1) => a1.lift(0) match {
+          // The top-level array is empty, so we should succeed emptily.
+          case None => result === Xor.Right(None)
+          case Some(j2) => j2.asArray match {
+            // The second-level value isn't an array, so we should fail.
+            case None => result.isLeft
+            case Some(a2) => a2.lift(1) match {
+              // The second-level array doesn't a second element, so we should succeed emptily.
+              case None => result === Xor.Right(None)
+              case Some(j3) => j3.asString match {
+                // The third-level value isn't a string, so we should fail.
+                case None => result.isLeft
+                // The third-level value is a string, so we should have decoded it.
+                case Some(s3) => result === Xor.Right(Some(s3))
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("Decoder[Byte] fails on out-of-range values (#83)") {
     check { (l: Long) =>
       val json = Json.fromLong(l)


### PR DESCRIPTION
## Update

Okay, tests are in place and I've confirmed that they fail as expected on the current master, so this is ready for review.

## Original description

This PR still needs tests but I think it's a reasonable solution for #226 and #217. The underlying abstractions (see #228) will change a bit in 0.5.0, so I don't want to spend too much time worrying about the implementations, but I do want to be sure we get the right behavior now.