### PR TITLE
Codecs for Some and None

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -552,6 +552,21 @@ final object Decoder extends TupleDecoders with LowPriorityDecoders {
   /**
    * @group Decoding
    */
+  implicit final def decodeSome[A](implicit d: Decoder[A]): Decoder[Some[A]] = d.map(Some(_))
+
+  /**
+   * @group Decoding
+   */
+  implicit final val decodeNone: Decoder[None.type] = new Decoder[None.type] {
+    final def apply(c: HCursor): Result[None.type] = if (c.focus.isNull) Xor.right(None) else {
+      Xor.left(DecodingFailure("None", c.history))
+    }
+  }
+
+
+  /**
+   * @group Decoding
+   */
   implicit final def decodeMapLike[M[K, +V] <: Map[K, V], K, V](implicit
     dk: KeyDecoder[K],
     dv: Decoder[V],

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -225,6 +225,18 @@ object Encoder extends TupleEncoders with LowPriorityEncoders {
   /**
    * @group Encoding
    */
+  implicit final def encodeSome[A](implicit e: Encoder[A]): Encoder[Some[A]] = e.contramap(_.x)
+
+  /**
+   * @group Encoding
+   */
+  implicit final val encodeNone: Encoder[None.type] = new Encoder[None.type] {
+    final def apply(a: None.type): Json = Json.Null
+  }
+
+  /**
+   * @group Encoding
+   */
   implicit final def encodeOneAnd[A0, C[_]](
     implicit ea: Encoder[A0],
     is: IsTraversableOnce[C[A0]] { type A = A0 }

--- a/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -2,7 +2,7 @@ package io.circe.tests
 
 import algebra.Eq
 import java.util.UUID
-import org.scalacheck.Arbitrary
+import org.scalacheck.{ Arbitrary, Gen }
 import shapeless._
 
 trait MissingInstances {
@@ -12,6 +12,12 @@ trait MissingInstances {
 
   implicit def arbitraryTuple1[A](implicit A: Arbitrary[A]): Arbitrary[Tuple1[A]] =
     Arbitrary(A.arbitrary.map(Tuple1(_)))
+
+  implicit def arbitrarySome[A](implicit A: Arbitrary[A]): Arbitrary[Some[A]] = Arbitrary(A.arbitrary.map(Some(_)))
+  implicit lazy val arbitraryNone: Arbitrary[None.type] = Arbitrary(Gen.const(None))
+
+  implicit def eqSome[A](implicit A: Eq[A]): Eq[Some[A]] = Eq.by(_.x)
+  implicit lazy val eqNone: Eq[None.type] = Eq.instance((_, _) => true)
 
   implicit lazy val arbitrarySymbol: Arbitrary[Symbol] = Arbitrary(Arbitrary.arbitrary[String].map(Symbol(_)))
 

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -41,6 +41,8 @@ class StdLibCodecSuite extends CirceSuite {
   checkAll("Codec[BigDecimal]", CodecTests[BigDecimal].codec)
   checkAll("Codec[UUID]", CodecTests[UUID].codec)
   checkAll("Codec[Option[Int]]", CodecTests[Option[Int]].codec)
+  checkAll("Codec[Some[Int]]", CodecTests[Some[Int]].codec)
+  checkAll("Codec[None.type]", CodecTests[None.type].codec)
   checkAll("Codec[List[Int]]", CodecTests[List[Int]].codec)
   checkAll("Codec[Map[String, Int]]", CodecTests[Map[String, Int]].codec)
   checkAll("Codec[Map[Symbol, Int]]", CodecTests[Map[Symbol, Int]].codec)

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -65,6 +65,8 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
             case Some(o2) => o2("") match {
               // The second-level object doesn't contain a "" key, so we should succeed emptily.
               case None => result === Xor.Right(None)
+              // The third-level value is null, so we succeed emptily.
+              case Some(j3) if j3.isNull => result === Xor.Right(None)
               case Some(j3) => j3.asString match {
                 // The third-level value isn't a string, so we should fail.
                 case None => result.isLeft
@@ -96,8 +98,10 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
             // The second-level value isn't an array, so we should fail.
             case None => result.isLeft
             case Some(a2) => a2.lift(1) match {
-              // The second-level array doesn't a second element, so we should succeed emptily.
+              // The second-level array doesn't have a second element, so we should succeed emptily.
               case None => result === Xor.Right(None)
+              // The third-level value is null, so we succeed emptily.
+              case Some(j3) if j3.isNull => result === Xor.Right(None)
               case Some(j3) => j3.asString match {
                 // The third-level value isn't a string, so we should fail.
                 case None => result.isLeft


### PR DESCRIPTION
This PR builds on #233 (for the sake of convenience only) and I'll rebase it once that's merged.

The issue is that while in general I don't think many people do or should encode or decode `Some` and `None` directly, it's possible and in some cases reasonable, and the current story is pretty confusing:

```scala
scala> Some(1).asJson.noSpaces
res0: String = [1]

scala> decode[Some[Int]]("[1]")
res1: cats.data.Xor[io.circe.Error,Some[Int]] = Left(io.circe.DecodingFailure: Attempt to decode value on failed cursor: El(DownField(x),false))

scala> None.asJson.noSpaces
res2: String = {}

scala> decode[None.type]("{}")
res3: cats.data.Xor[io.circe.Error,None.type] = Right(None)
```

These codecs are coming from all over the place—generic derivation, collection encoders, etc.

This PR provides explicit encoders and decoders for `Some` and `None` that behave more or less as you'd expect—decoding into `Some[A]` means you should be able to decode an `A`, and `None` is always encoded and decoded as a JSON null.

I've also snuck in a small fix for a test that was recently added as part of the optional decoding overhaul.