### PR TITLE
Add forProduct helper methods

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -172,9 +172,12 @@ trait Decoder[A] extends Serializable { self =>
  * @groupname Tuple Tuple instances
  * @groupprio Tuple 5
  *
+ * @groupname Product Case class and other product instances
+ * @groupprio Product 6
+ *
  * @author Travis Brown
  */
-final object Decoder extends TupleDecoders with LowPriorityDecoders {
+final object Decoder extends TupleDecoders with ProductDecoders with LowPriorityDecoders {
   import Json._
 
   type Result[A] = Xor[DecodingFailure, A]

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -59,9 +59,12 @@ trait Encoder[A] extends Serializable { self =>
  * @groupname Tuple Tuple instances
  * @groupprio Tuple 4
  *
+ * @groupname Product Case class and other product instances
+ * @groupprio Product 5
+ *
  * @author Travis Brown
  */
-object Encoder extends TupleEncoders with LowPriorityEncoders {
+object Encoder extends TupleEncoders with ProductEncoders with LowPriorityEncoders {
   /**
    * Return an instance for a given type `A`.
    *

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -23,7 +23,9 @@ object Boilerplate {
 
   val templates: Seq[Template] = Seq(
     GenTupleDecoders,
-    GenTupleEncoders
+    GenTupleEncoders,
+    GenProductDecoders,
+    GenProductEncoders
   )
 
   val header = "// auto-generated boilerplate"
@@ -122,16 +124,16 @@ object Boilerplate {
         -  /**
         -   * @group Tuple
         -   */
-        -  implicit def decodeTuple$arity[${`A..N`}](implicit $instances): Decoder[${`(A..N)`}] =
-        -    new Decoder[${`(A..N)`}] { self =>
-        -      def apply(c: HCursor): Decoder.Result[${`(A..N)`}] = c.as[Vector[HCursor]] match {
+        -  implicit final def decodeTuple$arity[${`A..N`}](implicit $instances): Decoder[${`(A..N)`}] =
+        -    new Decoder[${`(A..N)`}] {
+        -      final def apply(c: HCursor): Decoder.Result[${`(A..N)`}] = c.as[Vector[HCursor]] match {
         -        case Xor.Right(js) => if (js.size == $arity) {
         -          $result
         -        } else Xor.left(DecodingFailure("${`(A..N)`}", c.history))
         -        case l @ Xor.Left(_) => l
         -      }
         -
-        -      override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[${`(A..N)`}] =
+        -      override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[${`(A..N)`}] =
         -        c.as[Vector[HCursor]].leftMap[NonEmptyList[DecodingFailure]](NonEmptyList(_)).flatMap { js =>
         -          if (js.size == $arity) {
         -            $accumulatingResult.toXor
@@ -163,7 +165,7 @@ object Boilerplate {
         -  /**
         -   * @group Tuple
         -   */
-        -  implicit def encodeTuple$arity[${`A..N`}](implicit $instances): Encoder[${`(A..N)`}] =
+        -  implicit final def encodeTuple$arity[${`A..N`}](implicit $instances): Encoder[${`(A..N)`}] =
         -    new Encoder[${`(A..N)`}] {
         -      final def apply(a: ${`(A..N)`}): Json = Json.arr($applied)
         -    }
@@ -192,6 +194,88 @@ object Boilerplate {
         |class TupleCodecSuite extends CirceSuite {
         |  checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
         -  checkAll("Codec[$tupleType]", CodecTests[$tupleType].codec)
+        |}
+      """
+    }
+  }
+
+  object GenProductDecoders extends Template {
+    override def range: IndexedSeq[Int] = 1 to maxArity
+
+    def filename(root: File): File = root /  "io" / "circe" / "ProductDecoders.scala"
+
+    def content(tv: TemplateVals): String = {
+      import tv._
+
+      val instances = synTypes.map(tpe => s"decode$tpe: Decoder[$tpe]").mkString(", ")
+      val memberNames = synTypes.map(tpe => s"name$tpe: String").mkString(", ")
+
+      val results = synTypes.map(tpe => s"c.get[$tpe](name$tpe)(decode$tpe)").mkString(", ")
+
+      val accumulatingResults = synTypes.map(tpe =>
+        s"decode$tpe.tryDecodeAccumulating(c.downField(name$tpe))"
+      ).mkString(",")
+
+      val result =
+        if (arity == 1) s"($results).map(f)" else s"Decoder.resultInstance.map$arity($results)(f)"
+
+      val accumulatingResult =
+        if (arity == 1) s"$accumulatingResults.map(f)"
+          else s"AccumulatingDecoder.resultInstance.map$arity($accumulatingResults)(f)"
+
+      block"""
+        |package io.circe
+        |
+        |private[circe] trait ProductDecoders {
+        -  /**
+        -   * @group Product
+        -   */
+        -  final def forProduct$arity[${`A..N`}, Target]($memberNames)(f: (${`A..N`}) => Target)(implicit
+        -    $instances
+        -  ): Decoder[Target] =
+        -    new Decoder[Target] {
+        -      final def apply(c: HCursor): Decoder.Result[Target] = $result
+        -
+        -      override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[Target] =
+        -        $accumulatingResult
+        -    }
+        |}
+      """
+    }
+  }
+
+  object GenProductEncoders extends Template {
+    override def range: IndexedSeq[Int] = 1 to maxArity
+
+    def filename(root: File): File = root /  "io" / "circe" / "ProductEncoders.scala"
+
+    def content(tv: TemplateVals): String = {
+      import tv._
+
+      val instances = synTypes.map(tpe => s"encode$tpe: Encoder[$tpe]").mkString(", ")
+      val memberNames = synTypes.map(tpe => s"name$tpe: String").mkString(", ")
+      val kvs = if (arity == 1) s"(name${ synTypes.head }, encode${ synTypes.head }(members))" else {
+        synTypes.zipWithIndex.map {
+          case (tpe, i) => s"(name$tpe, encode$tpe(members._${ i + 1 }))"
+        }.mkString(", ")
+      }
+
+      block"""
+        |package io.circe
+        |
+        |private[circe] trait ProductEncoders {
+        -  /**
+        -   * @group Product
+        -   */
+        -  final def forProduct$arity[${`A..N`}, Source]($memberNames)(f: Source => (${`A..N`}))(implicit
+        -    $instances
+        -  ): ObjectEncoder[Source] =
+        -    new ObjectEncoder[Source] {
+        -      final def encodeObject(a: Source): JsonObject = {
+        -        val members = f(a)
+        -        JsonObject.fromIterable(Vector($kvs))
+        -      }
+        -    }
         |}
       """
     }


### PR DESCRIPTION
This PR finally addresses #26 (currently our oldest open issue).

What's new here is some code-gen-ed helper methods that are similar to Argonaut's `jdecodeNL` and `jencodeNL`. These methods (named `forProductN` here) support relatively convenient codec definitions for case class-like types:

```scala
import io.circe._, io.circe.jawn._, io.circe.syntax._

case class User(id: Long, firstName: String, lastName: String)

object User {
  implicit val decodeUser: Decoder[User] =
    Decoder.forProduct3("id", "first_name", "last_name")(User.apply)

  implicit val encodeUser: Encoder[User] =
    Encoder.forProduct3("id", "first_name", "last_name")(u =>
      (u.id, u.firstName, u.lastName)
    )
}
```

And then:

```scala
scala> val json = User(101, "Foo", "McBar").asJson
json: io.circe.Json =
{
  "id" : 101,
  "first_name" : "Foo",
  "last_name" : "McBar"
}

scala> decode[User](json.noSpaces)
res1: cats.data.Xor[io.circe.Error,User] = Right(User(101,Foo,McBar))
```

It's not as clean or as maintainable as generic derivation, but it's less magical and requires nothing but circe-core.

This PR still needs tests, and I'd appreciate feedback on the `forProductN` name (or any other details) before this gets merged.