### PR TITLE
Replace export-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ circe is a fork of Argonaut with a few important differences.
 
 ### Dependencies and modularity
 
-circe depends on [cats][cats] instead of [Scalaz][scalaz], and the `core` project has only two
-dependencies: cats-core and [export-hook][export-hook] (a lightweight mechanism for cleaner generic
-type class instance derivation).
+circe depends on [cats][cats] instead of [Scalaz][scalaz], and the `core` project has only one
+dependency (cats-core).
 
 Other subprojects bring in dependencies on [Jawn][jawn] (for parsing in the [`jawn`][circe-jawn]
 subproject), [Shapeless][shapeless] (for automatic codec derivation in [`generic`][circe-generic]),
@@ -412,7 +411,6 @@ limitations under the License.
 [code-of-conduct]: http://typelevel.org/conduct.html
 [discipline]: https://github.com/typelevel/discipline
 [encoder]: https://travisbrown.github.io/circe/api/#io.circe.Encoder$
-[export-hook]: https://github.com/milessabin/export-hook
 [finch]: https://github.com/finagle/finch
 [generic-cursor]: https://travisbrown.github.io/circe/api/#io.circe.GenericCursor
 [gitter]: https://gitter.im/travisbrown/circe

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val catsVersion = "0.4.1"
 lazy val jawnVersion = "0.8.4"
 lazy val shapelessVersion = "2.3.0"
 lazy val refinedVersion = "0.3.6"
+lazy val macroCompatVersion = "1.1.1"
 
 lazy val scalaTestVersion = "3.0.0-M9"
 lazy val scalaCheckVersion = "1.12.5"
@@ -38,10 +39,6 @@ lazy val baseSettings = Seq(
   ),
   scalacOptions in (Compile, console) := compilerOptions,
   scalacOptions in (Compile, test) := compilerOptions,
-  libraryDependencies ++= Seq(
-    "org.typelevel" %% "export-hook" % "1.1.0",
-    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-  ),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")
@@ -183,7 +180,9 @@ lazy val genericBase = crossProject.in(file("generic"))
   .settings(
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % shapelessVersion,
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+      "org.typelevel" %%% "macro-compat" % macroCompatVersion,
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )
   )
   .jsSettings(commonJsSettings: _*)
@@ -204,7 +203,8 @@ lazy val literalBase = crossProject.crossType(CrossType.Pure).in(file("literal")
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
-      "org.typelevel" %%% "macro-compat" % "1.1.1"
+      "org.typelevel" %%% "macro-compat" % macroCompatVersion,
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
     sources in (Compile, doc) := (
       CrossVersion.partialVersion(scalaVersion.value) match {
@@ -278,7 +278,8 @@ lazy val testsBase = crossProject.in(file("tests"))
       "org.scalatest" %%% "scalatest" % scalaTestVersion,
       "org.typelevel" %%% "cats-laws" % catsVersion,
       "org.typelevel" %%% "discipline" % disciplineVersion,
-      "eu.timepit" %%% "refined-scalacheck" % refinedVersion
+      "eu.timepit" %%% "refined-scalacheck" % refinedVersion,
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
     sourceGenerators in Test <+= (sourceManaged in Test).map(Boilerplate.genTests),
     unmanagedResourceDirectories in Compile +=
@@ -379,7 +380,8 @@ lazy val benchmark = project
       "io.spray" %% "spray-json" % "1.3.2",
       "io.github.netvl.picopickle" %% "picopickle-core" % "0.2.1",
       "io.github.netvl.picopickle" %% "picopickle-backend-jawn" % "0.2.1",
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )
   )
   .enablePlugins(JmhPlugin)

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -4,6 +4,7 @@ import cats.{ MonadError, SemigroupK }
 import cats.data.{ Kleisli, NonEmptyList, OneAnd, Validated, Xor }
 import cats.std.list._
 import cats.syntax.functor._
+import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.Builder
@@ -768,4 +769,6 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
 }
 
-@export.imports[Decoder] private[circe] trait LowPriorityDecoders
+private[circe] trait LowPriorityDecoders {
+  implicit def importedDecoder[A](implicit exported: Exported[Decoder[A]]): Decoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.data._
 import cats.functor.Contravariant
 import cats.Foldable
+import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.GenSeq
 import scala.collection.generic.IsTraversableOnce
@@ -316,4 +317,6 @@ object Encoder extends TupleEncoders with ProductEncoders with LowPriorityEncode
   }
 }
 
-@export.imports[Encoder] private[circe] trait LowPriorityEncoders
+private[circe] trait LowPriorityEncoders {
+  implicit def importedEncoder[A](implicit exported: Exported[ObjectEncoder[A]]): Encoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import io.circe.export.Exported
+
 /**
  * A type class that provides a conversion from a value of type `A` to a [[JsonObject]].
  *
@@ -39,4 +41,8 @@ object ObjectEncoder extends LowPriorityObjectEncoders {
   }
 }
 
-@export.imports[ObjectEncoder] private[circe] trait LowPriorityObjectEncoders
+private[circe] trait LowPriorityObjectEncoders {
+  implicit def importedObjectEncoder[A](implicit
+    exported: Exported[ObjectEncoder[A]]
+  ): ObjectEncoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/export/Exported.scala
+++ b/core/shared/src/main/scala/io/circe/export/Exported.scala
@@ -1,0 +1,3 @@
+package io.circe.export
+
+case class Exported[T](instance: T) extends AnyVal

--- a/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
@@ -1,0 +1,38 @@
+package io.circe.generic
+
+import io.circe.{ Decoder, ObjectEncoder }
+import io.circe.export.Exported
+import macrocompat.bundle
+import scala.reflect.macros.whitebox
+
+@bundle
+class DerivationMacros(val c: whitebox.Context) {
+  final def exportDecoderImpl[A: c.WeakTypeTag]: c.Expr[Exported[Decoder[A]]] = {
+    import c.universe._
+
+    val A = c.weakTypeOf[A]
+
+    c.typecheck(q"_root_.shapeless.lazily[_root_.io.circe.generic.decoding.DerivedDecoder[$A]]", silent = true) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedDecoder[$A]")
+      case t => c.Expr[Exported[Decoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.Decoder[$A])"
+      )
+    }
+  }
+
+  final def exportEncoderImpl[A: c.WeakTypeTag]: c.Expr[Exported[ObjectEncoder[A]]] = {
+    import c.universe._
+
+    val A = c.weakTypeOf[A]
+
+    c.typecheck(
+      q"_root_.shapeless.lazily[_root_.io.circe.generic.encoding.DerivedObjectEncoder[$A]]",
+      silent = true
+    ) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedObjectEncoder[$A]")
+      case t => c.Expr[Exported[ObjectEncoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.ObjectEncoder[$A])"
+      )
+    }
+  }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -3,7 +3,6 @@ package io.circe.generic
 import io.circe.{ Decoder, ObjectEncoder }
 import io.circe.export.Exported
 import scala.language.experimental.macros
-import scala.reflect.macros.whitebox.Context
 
 /**
  * Fully automatic codec derivation.
@@ -13,31 +12,6 @@ import scala.reflect.macros.whitebox.Context
  * sealed trait hierarchies, etc.
  */
 final object auto {
-  implicit def exportDecoder[A]: Exported[Decoder[A]] = macro exportDecoderImpl[A]
-  implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] = macro exportEncoderImpl[A]
-
-  def exportDecoderImpl[A](c: Context)(implicit A: c.WeakTypeTag[A]): c.Expr[Exported[Decoder[A]]] = {
-    import c.universe._
-
-    c.typecheck(q"_root_.shapeless.lazily[_root_.io.circe.generic.decoding.DerivedDecoder[$A]]", silent = true) match {
-      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedDecoder[$A]")
-      case t => c.Expr[Exported[Decoder[A]]](
-        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.Decoder[$A])"
-      )
-    }
-  }
-
-  def exportEncoderImpl[A](c: Context)(implicit A: c.WeakTypeTag[A]): c.Expr[Exported[ObjectEncoder[A]]] = {
-    import c.universe._
-
-    c.typecheck(
-      q"_root_.shapeless.lazily[_root_.io.circe.generic.encoding.DerivedObjectEncoder[$A]]",
-      silent = true
-    ) match {
-      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedObjectEncoder[$A]")
-      case t => c.Expr[Exported[ObjectEncoder[A]]](
-        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.ObjectEncoder[$A])"
-      )
-    }
-  }
+  implicit def exportDecoder[A]: Exported[Decoder[A]] = macro DerivationMacros.exportDecoderImpl[A]
+  implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] = macro DerivationMacros.exportEncoderImpl[A]
 }

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,8 +1,9 @@
 package io.circe.generic
 
-import export.reexports
-import io.circe.generic.decoding.DerivedDecoder
-import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.{ Decoder, ObjectEncoder }
+import io.circe.export.Exported
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
 
 /**
  * Fully automatic codec derivation.
@@ -11,5 +12,32 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * instances for tuples, case classes (if all members have instances), "incomplete" case classes,
  * sealed trait hierarchies, etc.
  */
-@reexports[DerivedDecoder, DerivedObjectEncoder]
-object auto
+final object auto {
+  implicit def exportDecoder[A]: Exported[Decoder[A]] = macro exportDecoderImpl[A]
+  implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] = macro exportEncoderImpl[A]
+
+  def exportDecoderImpl[A](c: Context)(implicit A: c.WeakTypeTag[A]): c.Expr[Exported[Decoder[A]]] = {
+    import c.universe._
+
+    c.typecheck(q"_root_.shapeless.lazily[_root_.io.circe.generic.decoding.DerivedDecoder[$A]]", silent = true) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedDecoder[$A]")
+      case t => c.Expr[Exported[Decoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.Decoder[$A])"
+      )
+    }
+  }
+
+  def exportEncoderImpl[A](c: Context)(implicit A: c.WeakTypeTag[A]): c.Expr[Exported[ObjectEncoder[A]]] = {
+    import c.universe._
+
+    c.typecheck(
+      q"_root_.shapeless.lazily[_root_.io.circe.generic.encoding.DerivedObjectEncoder[$A]]",
+      silent = true
+    ) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedObjectEncoder[$A]")
+      case t => c.Expr[Exported[ObjectEncoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.ObjectEncoder[$A])"
+      )
+    }
+  }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -7,7 +7,6 @@ import shapeless._, shapeless.labelled.{ FieldType, field }
 
 trait DerivedDecoder[A] extends Decoder[A]
 
-@export.exports
 final object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedDecoders {
   final def fromDecoder[A](decode: Decoder[A]): DerivedDecoder[A] = new DerivedDecoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] = decode(c)

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -5,7 +5,6 @@ import shapeless._, shapeless.labelled.FieldType
 
 trait DerivedObjectEncoder[A] extends ObjectEncoder[A]
 
-@export.exports
 final object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
   implicit final val encodeHNil: DerivedObjectEncoder[HNil] =
     new DerivedObjectEncoder[HNil] {


### PR DESCRIPTION
This PR is a proof-of-concept that removes the dependency on [export-hook](https://github.com/milessabin/export-hook) and replaces it with a simpler (but similar) mechanism.

I decided to try this for two reasons. The first is that I don't like the macro-generated method names that `@imports` introduces into the `Encoder` and `Decoder` companion objects (`fresh$macro$1` in the case of `Decoder` and `fresh$macro$4` for `Encoder`). These seem like a binary compatibility-breaking liability, so I decided to replace them with non-macro versions, and it turned out that once I'd done that export-hook wasn't providing all that much additional value.

The second reason is that as I've been trying to wrap up #164, I keep running into export-hook limitations (most along the lines of https://github.com/milessabin/export-hook/issues/24). If it turns out that this approach makes it easier to finish up one of my experiments for #164, I'll be pretty tempted to merge it.

It might also be possible to do this in an even simpler way (as @alexarchambault notes [on Gitter](https://gitter.im/travisbrown/circe?at=56ef004a8b806f6b7a18cfb9)).