### PR TITLE
Add example of fully non-derived decoders to sf-city-lots tutorial

### DIFF
--- a/examples/sf-city-lots/README.md
+++ b/examples/sf-city-lots/README.md
@@ -80,9 +80,32 @@ object Geometry {
 ```
 
 Note that we don't explicitly give decoder instances for `Polygon` or `MultiPolygon`—these are very
-simple types, and generic derivation will work for them. We can't use generic derivation for
-`Geometry`, though, since by default the derived decoder expects an enclosing object where the key
-name determines the subtype, like this:
+simple types, and generic derivation will work for them. If we wanted to avoid generic derivation
+entirely, we could skip the `io.circe.generic.auto._` import above and write instances for these two
+case classes by hand:
+
+```scala
+object Polygon {
+  implicit val decodePolygon: Decoder[Polygon] =
+    Decoder[List[List[Coord]]].prepare(
+      _.downField("coordinates")
+    ).map(Polygon(_))
+}
+
+object MultiPolygon {
+  implicit val decodeMultiPolygon: Decoder[MultiPolygon] =
+    Decoder[List[List[List[Coord]]]].prepare(
+      _.downField("coordinates")
+    ).map(MultiPolygon(_))
+}
+```
+
+Which approach you should prefer is a matter of taste and the details of your use case, but in
+general using generically derived instances when possible will result in less boilerplate and more
+maintainable code.
+
+We also can't use generic derivation for `Geometry`, since by default the derived decoder expects an
+enclosing object where the key name determines the subtype, like this:
 
 ```json
 {


### PR DESCRIPTION
As requested by [Mario Pastorelli](https://twitter.com/mapastr/status/713023454287675392). Rendered version available [here](https://github.com/travisbrown/circe/tree/topic/gd-less-example/examples/sf-city-lots#decoders) (at least until this PR gets merged, at which point it'll be [here](https://github.com/travisbrown/circe/tree/master/examples/sf-city-lots#decoders)).