### PR TITLE
Generic derivation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,8 @@ circe is a fork of Argonaut with a few important differences.
 
 ### Dependencies and modularity
 
-circe depends on [cats][cats] instead of [Scalaz][scalaz], and the `core` project has only two
-dependencies: cats-core and [export-hook][export-hook] (a lightweight mechanism for cleaner generic
-type class instance derivation).
+circe depends on [cats][cats] instead of [Scalaz][scalaz], and the `core` project has only one
+dependency (cats-core).
 
 Other subprojects bring in dependencies on [Jawn][jawn] (for parsing in the [`jawn`][circe-jawn]
 subproject), [Shapeless][shapeless] (for automatic codec derivation in [`generic`][circe-generic]),
@@ -412,7 +411,6 @@ limitations under the License.
 [code-of-conduct]: http://typelevel.org/conduct.html
 [discipline]: https://github.com/typelevel/discipline
 [encoder]: https://travisbrown.github.io/circe/api/#io.circe.Encoder$
-[export-hook]: https://github.com/milessabin/export-hook
 [finch]: https://github.com/finagle/finch
 [generic-cursor]: https://travisbrown.github.io/circe/api/#io.circe.GenericCursor
 [gitter]: https://gitter.im/travisbrown/circe

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -4,6 +4,7 @@ import cats.{ MonadError, SemigroupK }
 import cats.data.{ Kleisli, NonEmptyList, OneAnd, Validated, Xor }
 import cats.std.list._
 import cats.syntax.functor._
+import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.Builder
@@ -768,4 +769,6 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
 }
 
-@export.imports[Decoder] private[circe] trait LowPriorityDecoders
+private[circe] trait LowPriorityDecoders {
+  implicit def importedDecoder[A](implicit exported: Exported[Decoder[A]]): Decoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -25,7 +25,7 @@ trait Decoder[A] extends Serializable { self =>
     DecodingFailure("Attempt to decode value on failed cursor", c.any.history)
   )
 
-  private[circe] def tryDecodeAccumulating(c: ACursor): AccumulatingDecoder.Result[A] =
+  def tryDecodeAccumulating(c: ACursor): AccumulatingDecoder.Result[A] =
     if (c.succeeded) decodeAccumulating(c.any) else Validated.invalidNel(
       DecodingFailure("Attempt to decode value on failed cursor", c.history)
     )

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -3,6 +3,7 @@ package io.circe
 import cats.data._
 import cats.functor.Contravariant
 import cats.Foldable
+import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.GenSeq
 import scala.collection.generic.IsTraversableOnce
@@ -316,4 +317,6 @@ object Encoder extends TupleEncoders with ProductEncoders with LowPriorityEncode
   }
 }
 
-@export.imports[Encoder] private[circe] trait LowPriorityEncoders
+private[circe] trait LowPriorityEncoders {
+  implicit def importedEncoder[A](implicit exported: Exported[ObjectEncoder[A]]): Encoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -1,5 +1,7 @@
 package io.circe
 
+import io.circe.export.Exported
+
 /**
  * A type class that provides a conversion from a value of type `A` to a [[JsonObject]].
  *
@@ -39,4 +41,8 @@ object ObjectEncoder extends LowPriorityObjectEncoders {
   }
 }
 
-@export.imports[ObjectEncoder] private[circe] trait LowPriorityObjectEncoders
+private[circe] trait LowPriorityObjectEncoders {
+  implicit def importedObjectEncoder[A](implicit
+    exported: Exported[ObjectEncoder[A]]
+  ): ObjectEncoder[A] = exported.instance
+}

--- a/core/shared/src/main/scala/io/circe/export/Exported.scala
+++ b/core/shared/src/main/scala/io/circe/export/Exported.scala
@@ -1,0 +1,3 @@
+package io.circe.export
+
+case class Exported[T](instance: T) extends AnyVal

--- a/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
@@ -1,0 +1,267 @@
+package io.circe.generic
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.encoding.DerivedObjectEncoder
+import macrocompat.bundle
+import scala.reflect.macros.whitebox
+import shapeless.{ CNil, Coproduct, HList, HNil, Lazy }
+import shapeless.labelled.KeyTag
+
+@bundle
+class DerivationMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  /**
+   * Crash the attempted derivation because of a failure related to the
+   * specified type.
+   *
+   * Note that these failures are not generally visible to users.
+   */
+  def fail(tpe: Type): Nothing = c.abort(c.enclosingPosition, s"Cannot generically derive instance: $tpe")
+
+  /**
+   * Represents an element at the head of a `shapeless.HList` or
+   * `shapeless.Coproduct`.
+   */
+  case class Member(label: String, keyType: Type, valueType: Type, acc: Type)
+
+  /**
+   * Represents an `shapeless.HList` or `shapeless.Coproduct` type in a way
+   * that's more convenient to work with.
+   */
+  class Members(val underlying: List[Member]) {
+    /**
+     * Fold over the elements of this (co-)product while accumulating instances
+     * of some type class for each.
+     */
+    def fold[Z](resolver: Type => Tree)(init: Z)(f: (Member, TermName, Z) => Z): (List[Tree], Z) = {
+      val (instanceMap, result) = underlying.foldRight((Map.empty[Type, (TermName, Tree)], init)) {
+        case (member @ Member(_, _, valueType, _), (instanceMap, acc)) =>
+          val (instanceName, instance) = instanceMap.getOrElse(valueType, (TermName(c.freshName), resolver(valueType)))
+          val newInstances = instanceMap.updated(valueType, (instanceName, instance))
+
+          (newInstances, f(member, instanceName, acc))
+      }
+
+      val instanceDefs = instanceMap.values.map {
+        case (instanceName, instance) => q"private[this] val $instanceName = $instance"
+      }
+
+      (instanceDefs.toList, result)
+    }
+  }
+
+  object Members {
+    private[this] val ShapelessSym = typeOf[HList].typeSymbol.owner
+    private[this] val HNilSym = typeOf[HNil].typeSymbol
+    private[this] val HConsSym = typeOf[shapeless.::[_, _]].typeSymbol
+    private[this] val CNilSym = typeOf[CNil].typeSymbol
+    private[this] val CConsSym = typeOf[shapeless.:+:[_, _]].typeSymbol
+    private[this] val ShapelessLabelledType = typeOf[shapeless.labelled.type]
+    private[this] val KeyTagSym = typeOf[KeyTag[_, _]].typeSymbol
+    private[this] val ShapelessTagType = typeOf[shapeless.tag.type]
+    private[this] val ScalaSymbolType = typeOf[scala.Symbol]
+
+    case class Entry(label: String, keyType: Type, valueType: Type)
+
+    object Entry {
+      def unapply(tpe: Type): Option[(String, Type, Type)] = tpe.dealias match {
+        case RefinedType(List(fieldType, TypeRef(lt, KeyTagSym, List(tagType, taggedFieldType))), _)
+          if lt =:= ShapelessLabelledType && fieldType =:= taggedFieldType =>
+            tagType.dealias match {
+              case RefinedType(List(st, TypeRef(tt, ts, ConstantType(Constant(fieldKey: String)) :: Nil)), _)
+                if st =:= ScalaSymbolType && tt =:= ShapelessTagType =>
+                  Some((fieldKey, tagType, fieldType))
+              case _ => None
+            }
+        case _ => None
+      }
+    }
+
+    def fromType(tpe: Type): Option[Members] = tpe.dealias match {
+      case TypeRef(ThisType(ShapelessSym), HNilSym | CNilSym, Nil) => Some(new Members(Nil))
+      case acc @ TypeRef(ThisType(ShapelessSym), HConsSym | CConsSym, List(fieldType, tailType)) =>
+        fieldType match {
+          case Entry(label, keyType, valueType) => fromType(tailType).map(members =>
+            new Members(Member(label, keyType, valueType, acc) :: members.underlying)
+          )
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  def resolveInstance(tpe: Type, tcs: (Type, Boolean)*): Tree = tcs match {
+    case (tc, lazily) +: rest =>
+      val applied = appliedType(tc.typeConstructor, tpe)
+      val target = if (lazily) appliedType(typeOf[Lazy[_]].typeConstructor, applied) else applied
+      val inferred = c.inferImplicitValue(target, silent = true)
+
+      inferred match {
+        case EmptyTree => resolveInstance(tpe, rest: _*)
+        case instance if lazily => q"$instance.value"
+        case instance => instance
+      }
+    case _ => fail(tpe)
+  }
+
+  def decodeHList[R <: HList](implicit R: c.WeakTypeTag[R]): c.Expr[DerivedDecoder[R]] =
+    Members.fromType(R.tpe).fold(fail(R.tpe)) { members =>
+      val (instanceDefs, (result, accumulatingResult)) = members.fold(
+        tpe => resolveInstance(tpe, (typeOf[Decoder[_]], false))
+      )(
+        (
+          q"_root_.cats.data.Xor.right(_root_.shapeless.HNil: _root_.shapeless.HNil)",
+          q"_root_.cats.data.Validated.valid(_root_.shapeless.HNil: _root_.shapeless.HNil)"
+        )
+      ) {
+        case (Member(name, nameTpe, tpe, _), instanceName, (acc, accumulatingAcc)) => (
+          q"""
+            _root_.io.circe.Decoder.resultInstance.map2(
+              $instanceName.tryDecode(c.downField($name)),
+              $acc
+            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe](h), t))
+          """,
+          q"""
+            _root_.io.circe.AccumulatingDecoder.resultInstance.map2(
+              $instanceName.tryDecodeAccumulating(c.downField($name)),
+              $accumulatingAcc
+            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe](h), t))
+          """
+        )
+      }
+
+      c.Expr[DerivedDecoder[R]](
+        q"""
+          {
+            new _root_.io.circe.generic.decoding.DerivedDecoder[$R] {
+              ..$instanceDefs
+              final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[$R] = $result
+              override final def decodeAccumulating(
+                c: _root_.io.circe.HCursor
+              ): _root_.io.circe.AccumulatingDecoder.Result[$R] = $accumulatingResult
+            }: _root_.io.circe.generic.decoding.DerivedDecoder[$R]
+          }
+        """
+      )
+    }
+
+  private[this] val cnilXorFailure: Tree = q"""
+    _root_.cats.data.Xor.left[_root_.io.circe.DecodingFailure, _root_.shapeless.CNil](
+      _root_.io.circe.DecodingFailure("CNil", c.history)
+    )
+  """
+
+  private[this] val cnilValidatedNelFailure: Tree = q"""
+    _root_.cats.data.Validated.invalidNel[_root_.io.circe.DecodingFailure, _root_.shapeless.CNil](
+      _root_.io.circe.DecodingFailure("CNil", c.history)
+    )
+  """
+
+  def decodeCoproduct[R <: Coproduct](implicit R: c.WeakTypeTag[R]): c.Expr[DerivedDecoder[R]] =
+    Members.fromType(R.tpe).fold(fail(R.tpe)) { members =>
+      val (instanceDefs, (result, accumulatingResult)) = members.fold(
+        tpe => resolveInstance(tpe, (typeOf[Decoder[_]], false), (typeOf[DerivedDecoder[_]], true))
+      )(
+        (cnilXorFailure, cnilValidatedNelFailure)
+      ) {
+        case (Member(name, nameTpe, tpe, current), instanceName, (acc, accumulatingAcc)) => (
+          q"""
+            {
+              val result = c.downField($name)
+
+              if (result.succeeded) $instanceName.tryDecode(result).map(a =>
+                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe](a))
+              ) else $acc.map(last => _root_.shapeless.Inr(last): $current)
+            }
+          """,
+          q"""
+            {
+              val result = c.downField($name)
+
+              if (result.succeeded) $instanceName.tryDecodeAccumulating(result).map(a =>
+                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe](a))
+              ) else $accumulatingAcc.map(last => _root_.shapeless.Inr(last): $current)
+            }
+          """
+        )
+      }
+
+      c.Expr[DerivedDecoder[R]](
+        q"""
+          {
+            new _root_.io.circe.generic.decoding.DerivedDecoder[$R] {
+              ..$instanceDefs
+              final def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[$R] = $result
+              override final def decodeAccumulating(
+                c: _root_.io.circe.HCursor
+              ): _root_.io.circe.AccumulatingDecoder.Result[$R] = $accumulatingResult
+            }: _root_.io.circe.generic.decoding.DerivedDecoder[$R]
+          }
+        """
+      )
+    }
+
+  def encodeHList[R <: HList](implicit R: c.WeakTypeTag[R]): c.Expr[DerivedObjectEncoder[R]] =
+    Members.fromType(R.tpe).fold(fail(R.tpe)) { members =>
+      val (instanceDefs, (pattern, fields)) = members.fold(
+        tpe => resolveInstance(tpe, (typeOf[Encoder[_]], false))
+      )(
+        (pq"_root_.shapeless.HNil": Tree, List.empty[Tree])
+      ) {
+        case (Member(name, _, tpe, _), instanceName, (patternAcc, fieldsAcc)) =>
+        val currentName = TermName(c.freshName)
+
+        (pq"_root_.shapeless.::($currentName, $patternAcc)", q"$name -> $instanceName.apply($currentName)" :: fieldsAcc)
+      }
+
+      c.Expr[DerivedObjectEncoder[R]](
+        q"""
+          {
+            new _root_.io.circe.generic.encoding.DerivedObjectEncoder[$R] {
+              ..$instanceDefs
+              final def encodeObject(a: $R): _root_.io.circe.JsonObject = a match {
+                case $pattern => _root_.io.circe.JsonObject.fromIterable(Vector(..$fields))
+              }
+            }: _root_.io.circe.generic.encoding.DerivedObjectEncoder[$R]
+          }
+        """
+      )
+    }
+
+  def encodeCoproduct[R <: Coproduct](implicit R: c.WeakTypeTag[R]): c.Expr[DerivedObjectEncoder[R]] =
+    Members.fromType(R.tpe).fold(fail(R.tpe)) { members =>
+      val (instanceDefs, patternAndCase) = members.fold(
+        tpe => resolveInstance(tpe, (typeOf[Encoder[_]], false), (typeOf[DerivedObjectEncoder[_]], true))
+      )(
+        cq"""_root_.shapeless.Inr(_) => sys.error("Cannot encode CNil")"""
+      ) {
+        case (Member(name, _, tpe, _), instanceName, acc) =>
+        val tailName = TermName(c.freshName)
+        val currentName = TermName(c.freshName)
+
+        cq"""
+          _root_.shapeless.Inr($tailName) => $tailName match {
+            case _root_.shapeless.Inl($currentName) =>
+              _root_.io.circe.JsonObject.singleton($name, $instanceName.apply($currentName))
+            case $acc
+          }
+        """
+      }
+
+      c.Expr[DerivedObjectEncoder[R]](
+        q"""
+          {
+            new _root_.io.circe.generic.encoding.DerivedObjectEncoder[$R] {
+              ..$instanceDefs
+
+              final def encodeObject(a: $R): _root_.io.circe.JsonObject = _root_.shapeless.Inr(a) match {
+                case $patternAndCase
+              }
+            }: _root_.io.circe.generic.encoding.DerivedObjectEncoder[$R]
+          }
+        """
+      )
+    }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/ExportMacros.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/ExportMacros.scala
@@ -1,0 +1,38 @@
+package io.circe.generic
+
+import io.circe.{ Decoder, ObjectEncoder }
+import io.circe.export.Exported
+import macrocompat.bundle
+import scala.reflect.macros.whitebox
+
+@bundle
+class ExportMacros(val c: whitebox.Context) {
+  final def exportDecoderImpl[A: c.WeakTypeTag]: c.Expr[Exported[Decoder[A]]] = {
+    import c.universe._
+
+    val A = c.weakTypeOf[A]
+
+    c.typecheck(q"_root_.shapeless.lazily[_root_.io.circe.generic.decoding.DerivedDecoder[$A]]", silent = true) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedDecoder[$A]")
+      case t => c.Expr[Exported[Decoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.Decoder[$A])"
+      )
+    }
+  }
+
+  final def exportEncoderImpl[A: c.WeakTypeTag]: c.Expr[Exported[ObjectEncoder[A]]] = {
+    import c.universe._
+
+    val A = c.weakTypeOf[A]
+
+    c.typecheck(
+      q"_root_.shapeless.lazily[_root_.io.circe.generic.encoding.DerivedObjectEncoder[$A]]",
+      silent = true
+    ) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type DerivedObjectEncoder[$A]")
+      case t => c.Expr[Exported[ObjectEncoder[A]]](
+        q"new _root_.io.circe.export.Exported($t: _root_.io.circe.ObjectEncoder[$A])"
+      )
+    }
+  }
+}

--- a/generic/shared/src/main/scala/io/circe/generic/auto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/auto.scala
@@ -1,8 +1,8 @@
 package io.circe.generic
 
-import export.reexports
-import io.circe.generic.decoding.DerivedDecoder
-import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.{ Decoder, ObjectEncoder }
+import io.circe.export.Exported
+import scala.language.experimental.macros
 
 /**
  * Fully automatic codec derivation.
@@ -11,5 +11,7 @@ import io.circe.generic.encoding.DerivedObjectEncoder
  * instances for tuples, case classes (if all members have instances), "incomplete" case classes,
  * sealed trait hierarchies, etc.
  */
-@reexports[DerivedDecoder, DerivedObjectEncoder]
-object auto
+final object auto {
+  implicit def exportDecoder[A]: Exported[Decoder[A]] = macro ExportMacros.exportDecoderImpl[A]
+  implicit def exportEncoder[A]: Exported[ObjectEncoder[A]] = macro ExportMacros.exportEncoderImpl[A]
+}

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -7,7 +7,6 @@ import shapeless._, shapeless.labelled.{ FieldType, field }
 
 trait DerivedDecoder[A] extends Decoder[A]
 
-@export.exports
 final object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedDecoders {
   final def fromDecoder[A](decode: Decoder[A]): DerivedDecoder[A] = new DerivedDecoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] = decode(c)

--- a/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -1,76 +1,26 @@
 package io.circe.generic.decoding
 
-import cats.data.Xor
-import cats.syntax.cartesian._
-import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, HCursor }
-import shapeless._, shapeless.labelled.{ FieldType, field }
+import io.circe.{ AccumulatingDecoder, Decoder, HCursor }
+import io.circe.generic.DerivationMacros
+import scala.language.experimental.macros
+import shapeless.{ Coproduct, HList, LabelledGeneric, Lazy }
 
-trait DerivedDecoder[A] extends Decoder[A]
+abstract class DerivedDecoder[A] extends Decoder[A]
 
-final object DerivedDecoder extends IncompleteDerivedDecoders with LowPriorityDerivedDecoders {
-  final def fromDecoder[A](decode: Decoder[A]): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode(c)
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-      decode.decodeAccumulating(c)
-  }
+final object DerivedDecoder extends IncompleteDerivedDecoders {
+  implicit def decodeHList[R <: HList]: DerivedDecoder[R] = macro DerivationMacros.decodeHList[R]
+  implicit def decodeCoproduct[R <: Coproduct]: DerivedDecoder[R] = macro DerivationMacros.decodeCoproduct[R]
 
-  final implicit val decodeHNil: DerivedDecoder[HNil] =
-    new DerivedDecoder[HNil] {
-      final def apply(c: HCursor): Decoder.Result[HNil] = Xor.right(HNil)
-    }
-
-  implicit final val decodeCNil: DerivedDecoder[CNil] =
-    new DerivedDecoder[CNil] {
-      final def apply(c: HCursor): Decoder.Result[CNil] =
-        Xor.left(DecodingFailure("CNil", c.history))
-    }
-
-  implicit final def decodeCoproduct[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[Decoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
-    final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
-      c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
-        decodeTail.value(c).map(Inr(_))
-      ) { headJson =>
-        headJson.as(decodeHead.value).map(h => Inl(field(h)))
-      }
-  }
-
-  implicit final def decodeLabelledHList[K <: Symbol, H, T <: HList](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[Decoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :: T] = fromDecoder(
-    (decodeHead.value.prepare(_.downField(key.value.name)) |@| decodeTail.value).map(
-      (head, tail) => field[K](head) :: tail
-    )
-  )
-}
-
-private[circe] trait LowPriorityDerivedDecoders {
-  implicit final def decodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    decodeHead: Lazy[DerivedDecoder[H]],
-    decodeTail: Lazy[DerivedDecoder[T]]
-  ): DerivedDecoder[FieldType[K, H] :+: T] = new DerivedDecoder[FieldType[K, H] :+: T] {
-    final def apply(c: HCursor): Decoder.Result[FieldType[K, H] :+: T] =
-      c.downField(key.value.name).focus.fold[Xor[DecodingFailure, FieldType[K, H] :+: T]](
-        decodeTail.value(c).map(Inr(_))
-      ) { headJson =>
-        headJson.as(decodeHead.value).map(h => Inl(field(h)))
-      }
-  }
-
-  implicit final def decodeAdt[A, R <: Coproduct](implicit
+  implicit def decodeCaseClass[A, R <: HList](implicit
     gen: LabelledGeneric.Aux[A, R],
     decode: Lazy[DerivedDecoder[R]]
   ): DerivedDecoder[A] = new DerivedDecoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
+      decode.value.decodeAccumulating(c).map(gen.from)
   }
 
-  implicit final def decodeCaseClass[A, R <: HList](implicit
+  implicit def decodeAdt[A, R <: Coproduct](implicit
     gen: LabelledGeneric.Aux[A, R],
     decode: Lazy[DerivedDecoder[R]]
   ): DerivedDecoder[A] = new DerivedDecoder[A] {

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -5,7 +5,6 @@ import shapeless._, shapeless.labelled.FieldType
 
 trait DerivedObjectEncoder[A] extends ObjectEncoder[A]
 
-@export.exports
 final object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
   implicit final val encodeHNil: DerivedObjectEncoder[HNil] =
     new DerivedObjectEncoder[HNil] {

--- a/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/encoding/DerivedObjectEncoder.scala
@@ -1,79 +1,27 @@
 package io.circe.generic.encoding
 
-import io.circe.{ Encoder, JsonObject, ObjectEncoder }
-import shapeless._, shapeless.labelled.FieldType
+import io.circe.{ JsonObject, ObjectEncoder }
+import io.circe.generic.DerivationMacros
+import scala.language.experimental.macros
+import shapeless.{ Coproduct, HList, LabelledGeneric, Lazy }
 
-trait DerivedObjectEncoder[A] extends ObjectEncoder[A]
+abstract class DerivedObjectEncoder[A] extends ObjectEncoder[A]
 
-final object DerivedObjectEncoder extends LowPriorityDerivedObjectEncoders {
-  implicit final val encodeHNil: DerivedObjectEncoder[HNil] =
-    new DerivedObjectEncoder[HNil] {
-      final def encodeObject(a: HNil): JsonObject = JsonObject.empty
-    }
+final object DerivedObjectEncoder {
+  implicit def encodeHList[R <: HList]: DerivedObjectEncoder[R] = macro DerivationMacros.encodeHList[R]
+  implicit def encodeCoproduct[R <: Coproduct]: DerivedObjectEncoder[R] = macro DerivationMacros.encodeCoproduct[R]
 
-  implicit final val encodeCNil: DerivedObjectEncoder[CNil] =
-    new DerivedObjectEncoder[CNil] {
-      final def encodeObject(a: CNil): JsonObject =
-        sys.error("No JSON representation of CNil (this shouldn't happen)")
-    }
-
-  implicit final def encodeCoproduct[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[Encoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :+: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :+: T] {
-      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
-        case Inl(h) => JsonObject.singleton(
-          key.value.name,
-          encodeHead.value(h)
-        )
-        case Inr(t) => encodeTail.value.encodeObject(t)
-      }
-    }
-
-  implicit final def encodeLabelledHList[K <: Symbol, H, T <: HList](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[Encoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :: T] {
-      final def encodeObject(a: FieldType[K, H] :: T): JsonObject = a match {
-        case h :: t =>
-          (key.value.name -> encodeHead.value(h)) +: encodeTail.value.encodeObject(t)
-      }
-    }
-}
-
-private[circe] trait LowPriorityDerivedObjectEncoders {
-  implicit final def encodeCoproductDerived[K <: Symbol, H, T <: Coproduct](implicit
-    key: Witness.Aux[K],
-    encodeHead: Lazy[DerivedObjectEncoder[H]],
-    encodeTail: Lazy[DerivedObjectEncoder[T]]
-  ): DerivedObjectEncoder[FieldType[K, H] :+: T] =
-    new DerivedObjectEncoder[FieldType[K, H] :+: T] {
-      final def encodeObject(a: FieldType[K, H] :+: T): JsonObject = a match {
-        case Inl(h) => JsonObject.singleton(
-          key.value.name,
-          encodeHead.value(h)
-        )
-        case Inr(t) => encodeTail.value.encodeObject(t)
-      }
-    }
-
-  implicit final def encodeAdt[A, R <: Coproduct](implicit
+  implicit def caseClassEncoder[A, R <: HList](implicit
     gen: LabelledGeneric.Aux[A, R],
     encode: Lazy[DerivedObjectEncoder[R]]
-  ): DerivedObjectEncoder[A] =
-    new DerivedObjectEncoder[A] {
-      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
-    }
+  ): DerivedObjectEncoder[A] = new DerivedObjectEncoder[A] {
+    final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
+  }
 
-  implicit final def encodeCaseClass[A, R <: HList](implicit
+  implicit def adtEncoder[A, R <: Coproduct](implicit
     gen: LabelledGeneric.Aux[A, R],
     encode: Lazy[DerivedObjectEncoder[R]]
-  ): DerivedObjectEncoder[A] =
-    new DerivedObjectEncoder[A] {
-      final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
-    }
+  ): DerivedObjectEncoder[A] = new DerivedObjectEncoder[A] {
+    final def encodeObject(a: A): JsonObject = encode.value.encodeObject(gen.to(a))
+  }
 }


### PR DESCRIPTION
This PR incorporates the changes in #242 and fixes #69 and a number of similar examples that have turned up as broken over the past few months (such as [this large case class hierarchy](https://gist.github.com/travisbrown/f2bb3704202481e6c9f8)).

The basic idea is that instead of requiring the compiler to build up instances for hlists and coproducts inductively, we manually fold over a list of the element types in a macro. The principle is exactly the same, but this approach has a couple of advantages: it keeps us in control instead of just handing everything over to scalac to do whatever it does, and it allows us to avoid unnecessary implicit searches by reusing resolved instances for types that show up more than once.

The disadvantage is more code, and more fragile code, but it's not that much more (net +236 lines for this PR, and a lot of them are build stuff or comments), and it's not like the relevant parts of scalac were a model of robustness anyway.

These changes are split out from a larger piece of work on configurable generic derivation for #164, where I needed more control over prioritization, more access to the bigger picture for features like using defaults in decoding, and just more room to do more stuff without causing the compiler to give up.

I'd intended for 0.4.0 to include a first draft of configurable generic derivation, but eventually decided that these changes were substantial enough that I wanted to break them into two pieces—a first part that only changes the implementation for 0.4, and then the configuration parts in 0.5.

In addition to deriving some instances that just couldn't be compiled before, this PR speeds up compilation (from ~100s to ~53s for the test suite on my desktop), reduces jar size a bit (from 1152K to 836K for the Twitter API case classes), and even has a small effect on runtime performance (higher is better):

```
[info] Benchmark                                     Mode  Cnt        Score       Error  Units
[info] CirceDerivationBenchmark.decodeDerived (old) thrpt   40  1281441.475 ±  8085.489  ops/s
[info] CirceDerivationBenchmark.decodeDerived (new) thrpt   40  1345841.543 ±  6627.257  ops/s
[info] CirceDerivationBenchmark.encodeDerived (old) thrpt   40  1047943.868 ±  9168.659  ops/s
[info] CirceDerivationBenchmark.encodeDerived (new) thrpt   40  1118678.877 ±  8278.789  ops/s
```

I also turned up a few minor bugs that had been hidden in the previous implementation. For example, the optional error accumulation was getting lost inside ADTs:

```scala
scala> import io.circe._, io.circe.generic.auto._, io.circe.literal._
import io.circe._
import io.circe.generic.auto._
import io.circe.literal._

scala> sealed trait Base; case class Foo(xs: List[String]) extends Base
defined trait Base
defined class Foo

scala> val json = json"""{ "Foo": { "xs": [1, 2, true, false] }}"""
json: io.circe.Json = ...

scala> Decoder[Base].accumulating.apply(json.hcursor)
res0: io.circe.AccumulatingDecoder.Result[Base] = Invalid(OneAnd(DecodingFailure(String, List(El(DownArray,true,false), El(DownField(xs),true,false))),List()))
```

This code now returns all four errors, as expected.

The test suite is unchanged, and usage (for code that already works) should be unchanged.