### PR TITLE
Add new module for Spray (un)marshallers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -381,10 +381,18 @@ lazy val spray = project
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor" % "2.3.9",
       "io.spray" %% "spray-httpx" % "1.3.3",
-      "io.spray" %% "spray-routing-shapeless2" % "1.3.3" % "test",
+      /**
+       * spray-routing-shapeless2 depends on Shapeless 2.1, which uses a
+       * different suffix for Scala 2.10 than Shapeless 2.3 (the version brought
+       * in by circe-generic). Since this is only a test dependency, we simply
+       * exclude the transitive Shapeless 2.1 dependency to avoid conflicting
+       * cross-version suffixes on 2.10.
+       */
+      "io.spray" %% "spray-routing-shapeless2" % "1.3.3" % "test" exclude("com.chuusai", "shapeless_2.10.4"),
       "io.spray" %% "spray-testkit" % "1.3.3" % "test",
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
-      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full)
     )
   )
   .dependsOn(core, jawn, generic % "test")

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   jackson,
   optics,
   scalajs,
+  spray,
   streaming,
   benchmark
 ) ++ (
@@ -370,6 +371,24 @@ lazy val jackson = project
   )
   .dependsOn(core)
 
+lazy val spray = project
+  .settings(
+    description := "circe spray",
+    moduleName := "circe-spray"
+  )
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor" % "2.3.9",
+      "io.spray" %% "spray-httpx" % "1.3.3",
+      "io.spray" %% "spray-routing-shapeless2" % "1.3.3" % "test",
+      "io.spray" %% "spray-testkit" % "1.3.3" % "test",
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
+    )
+  )
+  .dependsOn(core, jawn, generic % "test")
+
 lazy val optics = project
   .settings(
     description := "circe optics",
@@ -483,6 +502,7 @@ val jvmProjects = Seq(
   "tests",
   "jawn",
   "jackson",
+  "spray",
   "benchmark"
 ) ++ (
   if (sys.props("java.specification.version") == "1.8") Seq("java8") else Nil
@@ -491,6 +511,7 @@ val jvmProjects = Seq(
 val jvmTestProjects = Seq(
   "tests",
   "optics",
+  "spray",
   "benchmark"
 ) ++ (
   if (sys.props("java.specification.version") == "1.8") Seq("java8") else Nil

--- a/spray/src/main/scala/io/circe/spray/CirceJsonSupport.scala
+++ b/spray/src/main/scala/io/circe/spray/CirceJsonSupport.scala
@@ -1,0 +1,28 @@
+package io.circe.spray
+
+import io.circe.{ Decoder, ObjectEncoder, Printer }
+import io.circe.jawn._
+import spray.http.{ ContentTypes, HttpCharsets, HttpEntity, MediaTypes }
+import spray.httpx.marshalling.Marshaller
+import spray.httpx.unmarshalling.Unmarshaller
+
+trait CirceJsonSupport {
+  def printer: Printer
+
+  implicit final def circeJsonUnmarshaller[A](implicit decoder: Decoder[A]): Unmarshaller[A] =
+    Unmarshaller[A](MediaTypes.`application/json`) {
+      case x: HttpEntity.NonEmpty =>
+        decode[A](x.asString(defaultCharset = HttpCharsets.`UTF-8`)).valueOr(throw _)
+    }
+
+  implicit final def circeJsonMarshaller[A](implicit encoder: ObjectEncoder[A]): Marshaller[A] =
+    Marshaller.delegate[A, String](ContentTypes.`application/json`) { value =>
+      printer.pretty(encoder(value))
+    }
+}
+
+trait NoSpacesCirceJsonSupport extends CirceJsonSupport {
+  final def printer: Printer = Printer.noSpaces
+}
+
+final object CirceJsonSupport extends NoSpacesCirceJsonSupport

--- a/spray/src/test/scala/io/circe/spray/CirceJsonSupportSuite.scala
+++ b/spray/src/test/scala/io/circe/spray/CirceJsonSupportSuite.scala
@@ -1,0 +1,69 @@
+package io.circe.spray
+
+import io.circe.{ Decoder, Encoder, ObjectEncoder }
+import org.scalatest.FunSuite
+import spray.httpx.unmarshalling._
+import spray.httpx.marshalling._
+import spray.http.{ ContentTypes, HttpCharsets, HttpEntity, MediaTypes }
+
+/**
+ * Copied from spray-httpx's test suite.
+ */
+case class Employee(fname: String, name: String, age: Int, id: Long, boardMember: Boolean) {
+  require(!boardMember || age > 40, "Board members must be older than 40")
+}
+
+object Employee {
+  val simple: Employee = Employee("Frank", "Smith", 42, 12345, false)
+  val json: String = """{"fname":"Frank","name":"Smith","age":42,"id":12345,"boardMember":false}"""
+
+  val utf8: Employee = Employee("Fränk", "Smi√", 42, 12345, false)
+  val utf8json: Array[Byte] =
+    """{
+      |  "fname": "Fränk",
+      |  "name": "Smi√",
+      |  "age": 42,
+      |  "id": 12345,
+      |  "boardMember": false
+      |}""".stripMargin.getBytes(HttpCharsets.`UTF-8`.nioCharset)
+
+  val illegalEmployeeJson: String =
+    """{"fname":"Little Boy","name":"Smith","age":7,"id":12345,"boardMember":true}"""
+
+  implicit val decodeEmployee: Decoder[Employee] =
+    Decoder.forProduct5("fname", "name", "age", "id", "boardMember")(Employee.apply)
+
+  implicit val encodeEmployee: ObjectEncoder[Employee] =
+    Encoder.forProduct5("fname", "name", "age", "id", "boardMember") {
+      case Employee(fname, name, age, id, boardMember) => (fname, name, age, id, boardMember)
+    }
+}
+
+class CirceJsonSupportSpec extends FunSuite {
+  import CirceJsonSupport._
+
+  test("providing unmarshalling support for a case class") {
+    val expected = Right(Employee.simple)
+
+    assert(HttpEntity(ContentTypes.`application/json`, Employee.json).as[Employee] === expected)
+  }
+
+  test("providing marshalling support for a case class") {
+    val expected = Right(HttpEntity(ContentTypes.`application/json`, Employee.json))
+
+    assert(marshal(Employee.simple) === expected)
+  }
+
+  test("using UTF-8 as the default charset for JSON source decoding") {
+    val expected = Right(Employee.utf8)
+
+    assert(HttpEntity(MediaTypes.`application/json`, Employee.utf8json).as[Employee] === expected)
+  }
+
+  test("provide proper error messages for requirement errors") {
+    val Left(MalformedContent(msg, Some(ex: IllegalArgumentException))) =
+      HttpEntity(MediaTypes.`application/json`, Employee.illegalEmployeeJson).as[Employee]
+
+    assert(msg === "requirement failed: Board members must be older than 40")
+  }
+}

--- a/spray/src/test/scala/io/circe/spray/TodoRouteSuite.scala
+++ b/spray/src/test/scala/io/circe/spray/TodoRouteSuite.scala
@@ -1,0 +1,39 @@
+package io.circe.spray
+
+import io.circe.generic.auto._
+import io.circe.syntax._
+import java.util.UUID
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
+import spray.routing.Directives._
+import spray.testkit.ScalatestRouteTest
+
+case class Todo(id: UUID, title: String, completed: Boolean, order: Int)
+
+object TodoRoute {
+  import CirceJsonSupport._
+
+  lazy val route = path("api" / "v1" / "todo") {
+    post {
+      entity(as[UUID => Todo]) { userData =>
+        complete(userData(UUID.randomUUID()))
+      }
+    }
+  }
+}
+
+class TodoRouteSuite extends FunSuite with ScalatestRouteTest with Checkers {
+  import CirceJsonSupport._
+
+  test("Our route should accept a partial todo and return a completed version") {  
+    check { (title: String, completed: Boolean, order: Int) =>
+      val fields = Map("title" -> title.asJson, "completed" -> completed.asJson, "order" -> order.asJson)
+
+      Post("/api/v1/todo", fields) ~> TodoRoute.route ~> check {
+        val todo = responseAs[Todo]
+
+        todo.title === title && todo.completed === completed && todo.order === order
+      }
+    }
+  }
+}


### PR DESCRIPTION
This module provides support for using circe with [Spray](http://spray.io/) (for akka-http, please see [akka-http-json](https://github.com/hseeberger/akka-http-json), which already includes circe support).

Note that if you're using circe's `generic` package together with spray-routing, you will have to use spray-routing-shapeless2, and even then you _may_ run into issues related to the fact that spray-routing-shapeless2 depends on Shapeless 2.1, while circe-generic uses Shapeless 2.3. If your code compiles, you're likely to be safe. If you're not using circe-generic, you don't need to worry about this conflict.

The module's tests include an example of using circe's [partial case class decoding](https://meta.plasm.us/posts/2015/06/21/deriving-incomplete-type-class-instances/) to accept posted JSON that includes all of a case class's fields but its ID:

```scala
lazy val route = path("api" / "v1" / "todo") {
  post {
    entity(as[UUID => Todo]) { userData =>
      complete(userData(UUID.randomUUID()))
    }
  }
}
```

This allows you to avoid maintaining multiple versions of a case class (or filling your case class with optional members) simply to have something that's the right shape for parsing POST bodies into.

Future versions of this package may include special support for error accumulation via circe's `AccumulatingDecoder`, but for now I want to keep things simple.