### PR TITLE
Change @JsonCodec to generate ObjectEncoder instances

### DIFF
--- a/generic/shared/src/main/scala/io/circe/generic/JsonCodecMacros.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/JsonCodecMacros.scala
@@ -1,6 +1,6 @@
 package io.circe.generic
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Decoder, Encoder, ObjectEncoder }
 import macrocompat.bundle
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
@@ -41,6 +41,7 @@ private[generic] class JsonCodecMacros(val c: blackbox.Context) {
 
   private[this] val DecoderClass = symbolOf[Decoder[_]]
   private[this] val EncoderClass = symbolOf[Encoder[_]]
+  private[this] val ObjectEncoderClass = symbolOf[ObjectEncoder[_]]
   private[this] val semiautoObj = symbolOf[semiauto.type].asClass.module
 
   private[this] def codec(clsDef: ClassDef): List[Tree] = {
@@ -52,12 +53,12 @@ private[generic] class JsonCodecMacros(val c: blackbox.Context) {
       val Type = tpname
       List(
         q"""implicit val $decodeNme: $DecoderClass[$Type] = $semiautoObj.deriveDecoder[$Type]""",
-        q"""implicit val $encodeNme: $EncoderClass[$Type] = $semiautoObj.deriveEncoder[$Type]"""
+        q"""implicit val $encodeNme: $ObjectEncoderClass[$Type] = $semiautoObj.deriveEncoder[$Type]"""
       )
     } else {
       val tparamNames = tparams.map(_.name)
       def mkImplicitParams(typeSymbol: TypeSymbol) =
-        tparamNames map { tparamName =>
+        tparamNames.map { tparamName =>
           val paramName = c.freshName(tparamName.toTermName)
           val paramType = tq"$typeSymbol[$tparamName]"
           q"$paramName: $paramType"
@@ -68,7 +69,7 @@ private[generic] class JsonCodecMacros(val c: blackbox.Context) {
       List(
         q"""implicit def $decodeNme[..$tparams](implicit ..$decodeParams): $DecoderClass[$Type] =
            $semiautoObj.deriveDecoder[$Type]""",
-        q"""implicit def $encodeNme[..$tparams](implicit ..$encodeParams): $EncoderClass[$Type] =
+        q"""implicit def $encodeNme[..$tparams](implicit ..$encodeParams): $ObjectEncoderClass[$Type] =
            $semiautoObj.deriveEncoder[$Type]"""
       )
     }

--- a/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -11,8 +11,8 @@ import shapeless.ops.record.RemoveAll
 /**
  * Semi-automatic codec derivation.
  *
- * This object provides helpers for creating [[io.circe.Decoder]] and [[io.circe.Encoder]] instances
- * for case classes, "incomplete" case classes, sealed trait hierarchies, etc.
+ * This object provides helpers for creating [[io.circe.Decoder]] and [[io.circe.ObjectEncoder]]
+ * instances for case classes, "incomplete" case classes, sealed trait hierarchies, etc.
  *
  * Typical usage will look like the following:
  *
@@ -23,7 +23,7 @@ import shapeless.ops.record.RemoveAll
  *
  *   object Foo {
  *     implicit val decodeFoo: Decoder[Foo] = deriveDecoder[Foo]
- *     implicit val encodeFoo: Encoder[Foo] = deriveEncoder[Foo]
+ *     implicit val encodeFoo: ObjectEncoder[Foo] = deriveEncoder[Foo]
  *   }
  * }}}
  */

--- a/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -2,6 +2,7 @@ package io.circe.generic
 
 import algebra.Eq
 import cats.std.AllInstances
+import io.circe.ObjectEncoder
 import io.circe.generic.jsoncodecmacrossuiteaux._
 import io.circe.tests.{ ArbitraryInstances, CirceSuite, CodecTests, MissingInstances }
 import org.scalacheck.{ Arbitrary, Gen }
@@ -144,4 +145,14 @@ class JsonCodecMacrosSuite extends CirceSuite {
   checkAll("Codec[Hierarchy]", CodecTests[Hierarchy].codec)
   checkAll("Codec[RecursiveHierarchy]", CodecTests[RecursiveHierarchy].codec)
   checkAll("Codec[SelfRecursiveWithOption]", CodecTests[SelfRecursiveWithOption].codec)
+
+  test("@JsonCodec should provide ObjectEncoder instances") {
+    ObjectEncoder[Simple]
+    ObjectEncoder[Single]
+    ObjectEncoder[Typed1[Int]]
+    ObjectEncoder[Typed2[Int, Long]]
+    ObjectEncoder[Hierarchy]
+    ObjectEncoder[RecursiveHierarchy]
+    ObjectEncoder[SelfRecursiveWithOption]
+  }
 }

--- a/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -2,7 +2,7 @@ package io.circe.generic
 
 import algebra.Eq
 import cats.data.Xor
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Decoder, Encoder, Json, ObjectEncoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.semiauto._
@@ -16,9 +16,9 @@ class SemiautoDerivedSuite extends CirceSuite {
   implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] = deriveDecoder
   implicit def encodeQux[A: Encoder]: Encoder[Qux[A]] = deriveEncoder
   implicit val decodeWub: Decoder[Wub] = deriveDecoder
-  implicit val encodeWub: Encoder[Wub] = deriveEncoder
+  implicit val encodeWub: ObjectEncoder[Wub] = deriveEncoder
   implicit val decodeFoo: Decoder[Foo] = deriveDecoder
-  implicit val encodeFoo: Encoder[Foo] = deriveEncoder
+  implicit val encodeFoo: ObjectEncoder[Foo] = deriveEncoder
 
   implicit val decodeIntlessQux: Decoder[Int => Qux[String]] =
     deriveFor[Int => Qux[String]].incomplete
@@ -45,7 +45,7 @@ class SemiautoDerivedSuite extends CirceSuite {
       Arbitrary(atDepth(0))
 
     implicit val decodeRecursiveAdtExample: Decoder[RecursiveAdtExample] = deriveDecoder
-    implicit val encodeRecursiveAdtExample: Encoder[RecursiveAdtExample] = deriveEncoder
+    implicit val encodeRecursiveAdtExample: ObjectEncoder[RecursiveAdtExample] = deriveEncoder
   }
 
   case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
@@ -65,7 +65,7 @@ class SemiautoDerivedSuite extends CirceSuite {
     implicit val decodeRecursiveWithOptionExample: Decoder[RecursiveWithOptionExample] =
       deriveDecoder
 
-    implicit val encodeRecursiveWithOptionExample: Encoder[RecursiveWithOptionExample] =
+    implicit val encodeRecursiveWithOptionExample: ObjectEncoder[RecursiveWithOptionExample] =
       deriveEncoder
   }
 
@@ -127,12 +127,12 @@ class SemiautoDerivedSuite extends CirceSuite {
     illTyped("Decoder[OvergenerationExampleInner]")
 
     implicitly[DerivedObjectEncoder[OvergenerationExampleInner]]
-    illTyped("Encoder[OvergenerationExampleInner]")
+    illTyped("ObjectEncoder[OvergenerationExampleInner]")
 
     illTyped("Decoder[OvergenerationExampleOuter0]")
-    illTyped("Encoder[OvergenerationExampleOuter0]")
+    illTyped("ObjectEncoder[OvergenerationExampleOuter0]")
     illTyped("Decoder[OvergenerationExampleOuter1]")
-    illTyped("Encoder[OvergenerationExampleOuter1]")
+    illTyped("ObjectEncoder[OvergenerationExampleOuter1]")
   }
 
   test("Semi-automatic derivation should require explicit instances for all parts") {


### PR DESCRIPTION
The semi-automatic derivation mechanism returns `ObjectEncoder` instances, but `@JsonCodec` was forgetting this by statically typing its instances as `Encoder`.