### PR TITLE
Add encoder type class for JSON root values

### DIFF
--- a/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ArrayEncoder.scala
@@ -1,0 +1,42 @@
+package io.circe
+
+/**
+ * A type class that provides a conversion from a value of type `A` to a JSON
+ * array.
+ *
+ * @author Travis Brown
+ */
+trait ArrayEncoder[A] extends RootEncoder[A] { self =>
+  final def apply(a: A): Json = Json.JArray(encodeArray(a))
+
+  /**
+   * Convert a value to a JSON array.
+   */
+  def encodeArray(a: A): List[Json]
+
+  /**
+   * Create a new [[ArrayEncoder]] by applying a function to the output of this
+   * one.
+   */
+  final def mapJsonArray(f: List[Json] => List[Json]): ArrayEncoder[A] = new ArrayEncoder[A] {
+    final def encodeArray(a: A): List[Json] = f(self.encodeArray(a))
+  }
+}
+
+final object ArrayEncoder {
+  /**
+   * Return an instance for a given type.
+   *
+   * @group Utilities
+   */
+  final def apply[A](implicit instance: ArrayEncoder[A]): ArrayEncoder[A] = instance
+
+  /**
+   * Construct an instance from a function.
+   *
+   * @group Utilities
+   */
+  final def instance[A](f: A => List[Json]): ArrayEncoder[A] = new ArrayEncoder[A] {
+    final def encodeArray(a: A): List[Json] = f(a)
+  }
+}

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -206,7 +206,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    *
    * @group Utilities
    */
-  final def apply[A](implicit d: Decoder[A]): Decoder[A] = d
+  final def apply[A](implicit instance: Decoder[A]): Decoder[A] = instance
 
   /**
    * Construct an instance from a function.

--- a/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/ObjectEncoder.scala
@@ -3,11 +3,12 @@ package io.circe
 import io.circe.export.Exported
 
 /**
- * A type class that provides a conversion from a value of type `A` to a [[JsonObject]].
+ * A type class that provides a conversion from a value of type `A` to a
+ * [[JsonObject]].
  *
  * @author Travis Brown
  */
-trait ObjectEncoder[A] extends Encoder[A] { self =>
+trait ObjectEncoder[A] extends RootEncoder[A] { self =>
   final def apply(a: A): Json = Json.JObject(encodeObject(a))
 
   /**
@@ -16,20 +17,21 @@ trait ObjectEncoder[A] extends Encoder[A] { self =>
   def encodeObject(a: A): JsonObject
 
   /**
-   * Create a new [[ObjectEncoder]] by applying a function to the output of this one.
+   * Create a new [[ObjectEncoder]] by applying a function to the output of this
+   * one.
    */
   final def mapJsonObject(f: JsonObject => JsonObject): ObjectEncoder[A] = new ObjectEncoder[A] {
     final def encodeObject(a: A): JsonObject = f(self.encodeObject(a))
   }
 }
 
-object ObjectEncoder extends LowPriorityObjectEncoders {
+final object ObjectEncoder extends LowPriorityObjectEncoders {
   /**
    * Return an instance for a given type.
    *
    * @group Utilities
    */
-  final def apply[A](implicit e: ObjectEncoder[A]): ObjectEncoder[A] = e
+  final def apply[A](implicit instance: ObjectEncoder[A]): ObjectEncoder[A] = instance
 
   /**
    * Construct an instance from a function.
@@ -42,7 +44,7 @@ object ObjectEncoder extends LowPriorityObjectEncoders {
 }
 
 private[circe] trait LowPriorityObjectEncoders {
-  implicit def importedObjectEncoder[A](implicit
+  implicit final def importedObjectEncoder[A](implicit
     exported: Exported[ObjectEncoder[A]]
   ): ObjectEncoder[A] = exported.instance
 }

--- a/core/shared/src/main/scala/io/circe/RootEncoder.scala
+++ b/core/shared/src/main/scala/io/circe/RootEncoder.scala
@@ -1,0 +1,25 @@
+package io.circe
+
+import io.circe.export.Exported
+
+/**
+ * A subtype of `Encoder` that statically verifies that the instance encodes
+ * either a JSON array or an object.
+ *
+ * @author Travis Brown
+ */
+trait RootEncoder[A] extends Encoder[A]
+
+final object RootEncoder extends LowPriorityRootEncoders {
+  /**
+   * Return an instance for a given type.
+   *
+   * @group Utilities
+   */
+  final def apply[A](implicit instance: RootEncoder[A]): RootEncoder[A] = instance
+}
+
+private[circe] trait LowPriorityRootEncoders {
+  implicit final def importedRootEncoder[A](implicit exported: Exported[ObjectEncoder[A]]): RootEncoder[A] =
+    exported.instance
+}

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -170,9 +170,9 @@ object Boilerplate {
         -  /**
         -   * @group Tuple
         -   */
-        -  implicit final def encodeTuple$arity[${`A..N`}](implicit $instances): Encoder[${`(A..N)`}] =
-        -    new Encoder[${`(A..N)`}] {
-        -      final def apply(a: ${`(A..N)`}): Json = Json.arr($applied)
+        -  implicit final def encodeTuple$arity[${`A..N`}](implicit $instances): ArrayEncoder[${`(A..N)`}] =
+        -    new ArrayEncoder[${`(A..N)`}] {
+        -      final def encodeArray(a: ${`(A..N)`}): List[Json] = List($applied)
         -    }
         |}
       """

--- a/spray/src/main/scala/io/circe/spray/CirceJsonSupport.scala
+++ b/spray/src/main/scala/io/circe/spray/CirceJsonSupport.scala
@@ -1,6 +1,6 @@
 package io.circe.spray
 
-import io.circe.{ Decoder, ObjectEncoder, Printer }
+import io.circe.{ Decoder, Printer, RootEncoder }
 import io.circe.jawn._
 import spray.http.{ ContentTypes, HttpCharsets, HttpEntity, MediaTypes }
 import spray.httpx.marshalling.Marshaller
@@ -15,7 +15,7 @@ trait CirceJsonSupport {
         decode[A](x.asString(defaultCharset = HttpCharsets.`UTF-8`)).valueOr(throw _)
     }
 
-  implicit final def circeJsonMarshaller[A](implicit encoder: ObjectEncoder[A]): Marshaller[A] =
+  implicit final def circeJsonMarshaller[A](implicit encoder: RootEncoder[A]): Marshaller[A] =
     Marshaller.delegate[A, String](ContentTypes.`application/json`) { value =>
       printer.pretty(encoder(value))
     }


### PR DESCRIPTION
According to [RFC 4627](https://tools.ietf.org/html/rfc4627),

> A JSON text is a serialized object or array.

And while RFC 4627 has been superseded by [RFC 7159](https://tools.ietf.org/html/rfc7159), which is more liberal, the older distinction is still relevant in many contexts (e.g. Spray).

Previously we had `ObjectEncoder`, which statically confirms that an encoder produces JSON objects. The change here adds a `RootEncoder`, which does the same but for either objects or arrays.