### PR TITLE
Fix for #272

### DIFF
--- a/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
+++ b/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
@@ -121,13 +121,13 @@ class DerivationMacros(val c: whitebox.Context) {
             _root_.io.circe.Decoder.resultInstance.map2(
               $instanceName.tryDecode(c.downField($name)),
               $acc
-            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe](h), t))
+            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe].apply[$tpe](h), t))
           """,
           q"""
             _root_.io.circe.AccumulatingDecoder.resultInstance.map2(
               $instanceName.tryDecodeAccumulating(c.downField($name)),
               $accumulatingAcc
-            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe](h), t))
+            )((h, t) => _root_.shapeless.::(_root_.shapeless.labelled.field[$nameTpe].apply[$tpe](h), t))
           """
         )
       }
@@ -172,7 +172,7 @@ class DerivationMacros(val c: whitebox.Context) {
               val result = c.downField($name)
 
               if (result.succeeded) $instanceName.tryDecode(result).map(a =>
-                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe](a))
+                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe].apply[$tpe](a))
               ) else $acc.map(last => _root_.shapeless.Inr(last): $current)
             }
           """,
@@ -181,7 +181,7 @@ class DerivationMacros(val c: whitebox.Context) {
               val result = c.downField($name)
 
               if (result.succeeded) $instanceName.tryDecodeAccumulating(result).map(a =>
-                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe](a))
+                _root_.shapeless.Inl(_root_.shapeless.labelled.field[$nameTpe].apply[$tpe](a))
               ) else $accumulatingAcc.map(last => _root_.shapeless.Inr(last): $current)
             }
           """

--- a/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -33,6 +33,15 @@ package object examples extends AllInstances with ArbitraryInstances with Missin
 }
 
 package examples {
+  case class Box[A](a: A)
+
+  object Box {
+    implicit def eqBox[A: Eq]: Eq[Box[A]] = Eq.by(_.a)
+
+    implicit def arbitraryBox[A](implicit A: Arbitrary[A]): Arbitrary[Box[A]] =
+      Arbitrary(A.arbitrary.map(Box(_)))
+  }
+
   case class Qux[A](i: Int, a: A, j: Int)
 
   object Qux {

--- a/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -13,8 +13,12 @@ import shapeless.Witness, shapeless.labelled.{ FieldType, field }
 import shapeless.test.illTyped
 
 class SemiautoDerivedSuite extends CirceSuite {
+  implicit def decodeBox[A: Decoder]: Decoder[Box[A]] = deriveDecoder
+  implicit def encodeBox[A: Encoder]: Encoder[Box[A]] = deriveEncoder
+
   implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] = deriveDecoder
   implicit def encodeQux[A: Encoder]: Encoder[Qux[A]] = deriveEncoder
+
   implicit val decodeWub: Decoder[Wub] = deriveDecoder
   implicit val encodeWub: ObjectEncoder[Wub] = deriveEncoder
   implicit val decodeFoo: Decoder[Foo] = deriveDecoder
@@ -75,6 +79,7 @@ class SemiautoDerivedSuite extends CirceSuite {
 
   checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
   checkAll("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
+  checkAll("Codec[Box[Int]]", CodecTests[Box[Int]].codec)
   checkAll("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
   checkAll("Codec[Foo]", CodecTests[Foo].codec)
   checkAll("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)


### PR DESCRIPTION
Fixes #272. This change doesn't affect binary compatibility, so once it's merged I'll backport it to the 0.4 series and publish an 0.4.1.

I've added a test to verify that this doesn't get broken again (and confirmed that it fails without the change).

Note that derivation for encoders wasn't failing in this case (just decoders), but I've made the change across both for consistency's sake.