### PR TITLE
Add hygiene compilation test sub-project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
     then sbt ++$TRAVIS_SCALA_VERSION clean validateJS;
     else
       sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM &&
+      sbt hygiene/compile &&
       sbt ++$TRAVIS_SCALA_VERSION coverageReport && codecov;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,14 @@ install:
   - pip install --user codecov
 
 script:
+  - if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]];
+    then sbt ++$TRAVIS_SCALA_VERSION hygiene/compile;
+    else echo "Skipping hygiene tests on 2.10";
+    fi
   - if [[ "$TRAVIS_BRANCH" == "scalajs" ]];
     then sbt ++$TRAVIS_SCALA_VERSION clean validateJS;
     else
       sbt ++$TRAVIS_SCALA_VERSION clean coverage validateJVM &&
-      sbt hygiene/compile &&
       sbt ++$TRAVIS_SCALA_VERSION coverageReport && codecov;
     fi
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ lazy val commonJsSettings = Seq(
 def noDocProjects(sv: String): Seq[ProjectReference] = Seq[ProjectReference](
   benchmark,
   coreJS,
+  hygiene,
   java8,
   literalJS,
   genericJS,

--- a/build.sbt
+++ b/build.sbt
@@ -332,6 +332,17 @@ lazy val testsBase = crossProject.in(file("tests"))
 lazy val tests = testsBase.jvm
 lazy val testsJS = testsBase.js
 
+lazy val hygiene = project
+  .settings(
+    description := "circe hygiene",
+    moduleName := "circe-hygiene"
+  )
+  .settings(allSettings ++ noPublishSettings)
+  .settings(
+    scalacOptions ++= Seq("-Yno-imports", "-Yno-predef")
+  )
+  .dependsOn(core, generic, jawn, literal)
+
 lazy val jawn = project
   .settings(
     description := "circe jawn",
@@ -542,7 +553,10 @@ val jsProjects = Seq(
 )
 
 addCommandAlias("buildJVM", jvmProjects.map(";" + _ + "/compile").mkString)
-addCommandAlias("validateJVM", ";buildJVM" + jvmTestProjects.map(";" + _ + "/test").mkString + ";scalastyle;unidoc")
+addCommandAlias(
+  "validateJVM",
+  ";buildJVM" + jvmTestProjects.map(";" + _ + "/test").mkString + ";scalastyle;unidoc"
+)
 addCommandAlias("buildJS", jsProjects.map(";" + _ + "/compile").mkString)
 addCommandAlias("validateJS", ";buildJS;testsJS/test;scalastyle")
 addCommandAlias("validate", ";validateJVM;validateJS")

--- a/hygiene/src/main/scala/io/circe/hygiene/HygieneTests.scala
+++ b/hygiene/src/main/scala/io/circe/hygiene/HygieneTests.scala
@@ -1,0 +1,45 @@
+package io.circe.hygiene
+
+import io.circe.{ Decoder, Encoder, Json }
+import io.circe.generic.auto._
+import io.circe.generic.semiauto._
+import io.circe.literal._
+import scala.StringContext
+
+sealed trait Base
+
+case class Foo(
+  s: java.lang.String,
+  i: scala.Int,
+  o: scala.Option[scala.Double],
+  b: scala.List[scala.Boolean]
+) extends Base
+
+case object Bar extends Base
+
+/**
+ * Compilation tests for macro hygiene.
+ *
+ * Fake definitions suggested by Jason Zaugg.
+ */
+object HygieneTests {
+  val scala, Any, String, Unit = ()
+  trait scala; trait Any; trait String; trait Unit
+
+  val autoDerivedBaseEncoder: Encoder[Base] = Encoder[Base]
+  val derivedBaseEncoder: Encoder[Base] = deriveEncoder[Base]
+
+  val autoDerivedBaseDecoder: Decoder[Base] = Decoder[Base]
+  val derivedBaseDecoder: Decoder[Base] = deriveDecoder[Base]
+
+  val json: Json = json"""
+    {
+      "foo": {
+        "s": "abcdef",
+        "i": 10001,
+        "o": 10.01,
+        "b": [ true, false ]
+      }
+    }
+  """
+}


### PR DESCRIPTION
This PR adds a new `hygiene` sub-project that provides tests for #298 (fixed by @fthomas in #299). I'm made `hygiene` a separate project so that we don't have to turn on `-Yno-predef` for the `test` project generally. The fake definitions for common type and package names were suggested by @retronym [here](https://github.com/scala/pickling/issues/329).

I've confirmed that both `Encoder` derivation lines fail without the fix in #299.