### PR TITLE
Remove Scoverage dependencies from POM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import sbtunidoc.Plugin.UnidocKeys._
 import ReleaseTransformations._
+import scala.xml.transform.{ RewriteRule, RuleTransformer }
 
 lazy val buildSettings = Seq(
   organization := "io.circe",
@@ -450,6 +451,18 @@ lazy val benchmark = project
   .enablePlugins(JmhPlugin)
   .dependsOn(core, generic, jawn, jackson)
 
+val removeScoverage = new RuleTransformer(
+  new RewriteRule {
+    private[this] def isGroupScoverage(child: xml.Node): Boolean =
+      child.label == "groupId" && child.text == "org.scoverage"
+
+    override def transform(node: xml.Node): Seq[xml.Node] = node match {
+      case e: xml.Elem if e.label == "dependency" && e.child.exists(isGroupScoverage) => Nil
+      case _ => Seq(node)
+    }
+  }
+)
+
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -481,7 +494,8 @@ lazy val publishSettings = Seq(
         <url>https://twitter.com/travisbrown</url>
       </developer>
     </developers>
-  )
+  ),
+  pomPostProcess := { (node: xml.Node) => removeScoverage.transform(node).head }
 )
 
 lazy val noPublishSettings = Seq(


### PR DESCRIPTION
See [this Cats issue](https://github.com/typelevel/cats/issues/980) and [the fix](https://github.com/typelevel/cats/pull/1154), which I've pretty much copy-pasted.