### PR TITLE
Added encoder and decoder for Scala Enumeration

### DIFF
--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -788,6 +788,17 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       final def raiseError[A](e: DecodingFailure): Decoder[A] = Decoder.failed(e)
       final def handleErrorWith[A](fa: Decoder[A])(f: DecodingFailure => Decoder[A]): Decoder[A] = fa.handleErrorWith(f)
     }
+
+  /**
+    * @group Enumeration
+    * {{{
+    *   object WeekDay extends Enumeration { ... }
+    *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
+    * }}}
+    */
+  final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] = new Decoder[E#Value] {
+    override def apply(c: HCursor): Result[E#Value] = Decoder.decodeString.map(str => enum.withName(str))(c)
+  }
 }
 
 private[circe] trait LowPriorityDecoders {

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -796,9 +796,12 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     *   implicit val weekDayDecoder = Decoder.enumDecoder(WeekDay)
     * }}}
     */
-  final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] = new Decoder[E#Value] {
-    override def apply(c: HCursor): Result[E#Value] = Decoder.decodeString.map(str => enum.withName(str))(c)
-  }
+  final def enumDecoder[E <: Enumeration](enum: E): Decoder[E#Value] =
+    Decoder.decodeString.flatMap { str =>
+      Decoder.instanceTry { _ =>
+        Try(enum.withName(str))
+      }
+    }
 }
 
 private[circe] trait LowPriorityDecoders {

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -300,6 +300,17 @@ object Encoder extends TupleEncoders with ProductEncoders with MidPriorityEncode
   implicit final val contravariantEncoder: Contravariant[Encoder] = new Contravariant[Encoder] {
     final def contramap[A, B](e: Encoder[A])(f: B => A): Encoder[B] = e.contramap(f)
   }
+
+  /**
+    * @group Enumeration
+    * {{{
+    *   object WeekDay extends Enumeration { ... }
+    *   implicit val weekDayEncoder = Encoder.enumEncoder(WeekDay)
+    * }}}
+    */
+  final def enumEncoder[E <: Enumeration](enum: E): Encoder[E#Value] = new Encoder[E#Value] {
+    override def apply(e: E#Value): Json = Encoder.encodeString(e.toString)
+  }
 }
 
 private[circe] trait MidPriorityEncoders extends LowPriorityEncoders {

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -243,7 +243,7 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
     assert(decoder.apply(friday.hcursor) == Xor.right(WeekDay.Fri))
   }
 
-  "Decoder[Enumeration]" should "throw on unknown values in Scala Enumerations" in {
+  "Decoder[Enumeration]" should "fail on unknown values in Scala Enumerations" in {
     object WeekDay extends Enumeration {
       type WeekDay = Value
       val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
@@ -252,12 +252,6 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
     val decoder = Decoder.enumDecoder(WeekDay)
     val Xor.Right(friday) = parse("\"Friday\"")
 
-    val success = try {
-      decoder.apply(friday.hcursor)
-      true
-    } catch {
-      case _: NoSuchElementException => false
-    }
-    assert(success === false)
+    assert(decoder.apply(friday.hcursor).isEmpty)
   }
 }

--- a/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -231,4 +231,33 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
 
     assert(Decoder[BigInt].apply(bigNumber.hcursor).isEmpty)
   }
+
+  "Decoder[Enumeration]" should "parse Scala Enumerations" in {
+    object WeekDay extends Enumeration {
+      type WeekDay = Value
+      val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+    }
+
+    val decoder = Decoder.enumDecoder(WeekDay)
+    val Xor.Right(friday) = parse("\"Fri\"")
+    assert(decoder.apply(friday.hcursor) == Xor.right(WeekDay.Fri))
+  }
+
+  "Decoder[Enumeration]" should "throw on unknown values in Scala Enumerations" in {
+    object WeekDay extends Enumeration {
+      type WeekDay = Value
+      val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+    }
+
+    val decoder = Decoder.enumDecoder(WeekDay)
+    val Xor.Right(friday) = parse("\"Friday\"")
+
+    val success = try {
+      decoder.apply(friday.hcursor)
+      true
+    } catch {
+      case _: NoSuchElementException => false
+    }
+    assert(success === false)
+  }
 }

--- a/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -15,4 +15,16 @@ class EncoderSuite extends CirceSuite {
 
     assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Xor.right(m.updated(k, v)))
   }
+
+  "Encoder[Enumeration]" should "write Scala Enumerations" in {
+    object WeekDay extends Enumeration {
+      type WeekDay = Value
+      val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+    }
+
+    implicit val encoder = Encoder.enumEncoder(WeekDay)
+    val json = WeekDay.Fri.asJson
+    val decoder = Decoder.enumDecoder(WeekDay)
+    assert(decoder.apply(json.hcursor) == Xor.right(WeekDay.Fri))
+  }
 }


### PR DESCRIPTION
Added an encoder and a decoder for Scala Enumerations.

Parsing an enumeration value that doesn't exist will result in a `DecodingFailure` that contains a `NoSuchElementException`.

To summarize why:
- In some cases they are actually useful (convenience methods for example)
- Sometimes you don't have control over how the domain model looks
- They are a part of the Scala standard lib

Fixes #297
