### PR TITLE
Change level of the file length rule

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -7,7 +7,7 @@
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
         <parameters>
             <parameter name="maxFileLength"><![CDATA[800]]></parameter>
         </parameters>


### PR DESCRIPTION
`Decoder.scala` needs to shrink a bit but I don't think that needs to happen immediately (especially since a large proportion of the lines are docs).