### PR TITLE
Add Context.fold method

### DIFF
--- a/core/shared/src/main/scala/io/circe/Context.scala
+++ b/core/shared/src/main/scala/io/circe/Context.scala
@@ -4,9 +4,9 @@ import cats.{ Eq, Show }
 
 sealed abstract class Context extends Serializable {
   def json: Json
+  def field: Option[String]
+  def index: Option[Int]
   def fold[X](field: String => X, index: Int => X): X
-  final def field: Option[String] = fold(Some.apply, _ => None)
-  final def index: Option[Int] = fold(_ => None, Some.apply)
 }
 
 final object Context {
@@ -14,10 +14,14 @@ final object Context {
   final def inObject(j: Json, f: String): Context = ObjectContext(j, f)
 
   private[this] final case class ArrayContext(json: Json, i: Int) extends Context {
+    def field: Option[String] = None
+    def index: Option[Int] = Some(i)
     def fold[X](field: String => X, index: Int => X): X = index(i)
   }
 
   private[this] final case class ObjectContext(json: Json, f: String) extends Context {
+    def field: Option[String] = Some(f)
+    def index: Option[Int] = None
     def fold[X](field: String => X, index: Int => X): X = field(f)
   }
 

--- a/core/shared/src/main/scala/io/circe/Context.scala
+++ b/core/shared/src/main/scala/io/circe/Context.scala
@@ -4,8 +4,9 @@ import cats.{ Eq, Show }
 
 sealed abstract class Context extends Serializable {
   def json: Json
-  def field: Option[String]
-  def index: Option[Int]
+  def fold[X](field: String => X, index: Int => X): X
+  final def field: Option[String] = fold(Some.apply, _ => None)
+  final def index: Option[Int] = fold(_ => None, Some.apply)
 }
 
 final object Context {
@@ -13,13 +14,11 @@ final object Context {
   final def inObject(j: Json, f: String): Context = ObjectContext(j, f)
 
   private[this] final case class ArrayContext(json: Json, i: Int) extends Context {
-    def field: Option[String] = None
-    def index: Option[Int] = Some(i)
+    def fold[X](field: String => X, index: Int => X): X = index(i)
   }
 
   private[this] final case class ObjectContext(json: Json, f: String) extends Context {
-    def field: Option[String] = Some(f)
-    def index: Option[Int] = None
+    def fold[X](field: String => X, index: Int => X): X = field(f)
   }
 
   implicit final val eqContext: Eq[Context] = Eq.instance {


### PR DESCRIPTION
A `Context` is either an `ObjectContext` or an `ArrayContext`. However, distinguishing them by pattern matching is not possible, since these subclasses are private. The existing `field` and `index` methods give access to the data in these subclasses, but they both return `Option`s: exactly one of these will be `Some`, but this is not visible in the types.

This PR adds a `fold` method to `Context`, which makes it possible to process `Context`s in a pattern match-like way, without resorting to `Option.get` or similar things.