### PR TITLE
Optimization for sequence and map decoders (do not merge)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "0.6.1"
+lazy val catsVersion = "0.7.0-SNAPSHOT"
 lazy val jawnVersion = "0.8.4"
 lazy val shapelessVersion = "2.3.1"
 lazy val refinedVersion = "0.5.0"
@@ -371,7 +371,7 @@ lazy val streaming = project
   )
   .settings(allSettings)
   .settings(
-    libraryDependencies += "io.iteratee" %% "iteratee-core" % "0.5.0"
+    libraryDependencies += "io.iteratee" %% "iteratee-core" % "0.6.0-SNAPSHOT"
   )
   .dependsOn(core, jawn)
 

--- a/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -1,7 +1,7 @@
 package io.circe
 
 import cats.{ ApplicativeError, Semigroup, SemigroupK }
-import cats.data.{ NonEmptyList, OneAnd, Validated, ValidatedNel }
+import cats.data.{ NonEmptyList, Validated, ValidatedNel }
 
 sealed trait AccumulatingDecoder[A] extends Serializable { self =>
   /**
@@ -50,10 +50,10 @@ final object AccumulatingDecoder {
   final type Result[A] = ValidatedNel[DecodingFailure, A]
 
   final val failureNelInstance: Semigroup[NonEmptyList[DecodingFailure]] =
-    OneAnd.oneAndSemigroup[List, DecodingFailure](cats.std.list.listInstance)
+    NonEmptyList.catsDataSemigroupForNonEmptyList[DecodingFailure]
 
   final val resultInstance: ApplicativeError[Result, NonEmptyList[DecodingFailure]] =
-    Validated.validatedInstances[NonEmptyList[DecodingFailure]](failureNelInstance)
+    Validated.catsDataInstancesForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
 
   /**
    * Return an instance for a given type.

--- a/core/shared/src/main/scala/io/circe/Cursor.scala
+++ b/core/shared/src/main/scala/io/circe/Cursor.scala
@@ -1,7 +1,7 @@
 package io.circe
 
 import cats.{ Eq, Functor, Id, Show }
-import cats.std.list._
+import cats.instances.list._
 import io.circe.cursor.{ CArray, CJson, CObject }
 import scala.annotation.tailrec
 

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -586,7 +586,6 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
   }
 
-
   /**
    * @group Decoding
    */

--- a/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -5,7 +5,6 @@ import cats.data.{ Kleisli, NonEmptyList, NonEmptyVector, OneAnd, Validated, Xor
 import io.circe.export.Exported
 import java.util.UUID
 import scala.collection.generic.CanBuildFrom
-import scala.collection.mutable.Builder
 import scala.util.{ Failure, Success, Try }
 
 trait Decoder[A] extends Serializable { self =>
@@ -595,75 +594,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     dk: KeyDecoder[K],
     dv: Decoder[V],
     cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]
-  ): Decoder[M[K, V]] = new Decoder[M[K, V]] {
-    private[this] def failure(c: HCursor): DecodingFailure = DecodingFailure("[K, V]Map[K, V]", c.history)
-
-    def apply(c: HCursor): Result[M[K, V]] = c.fields match {
-      case None => Xor.left[DecodingFailure, M[K, V]](failure(c))
-      case Some(fields) =>
-        val builder = cbf()
-        spinResult(fields, c, builder) match {
-          case None => Xor.right(builder.result())
-          case Some(error) => Xor.left(error)
-        }
-    }
-
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[M[K, V]] =
-      c.fields match {
-        case None => Validated.invalidNel(failure(c))
-        case Some(fields) =>
-          val builder = cbf()
-          spinAccumulating(fields, c, builder, false, List.newBuilder[DecodingFailure]) match {
-            case Nil => Validated.valid(builder.result())
-            case error :: errors => Validated.invalid(NonEmptyList(error, errors))
-          }
-      }
-
-    @scala.annotation.tailrec
-    private[this] def spinResult(
-      fields: List[String],
-      c: HCursor,
-      builder: Builder[(K, V), M[K, V]]
-    ): Option[DecodingFailure] = fields match {
-      case Nil => None
-      case h :: t =>
-        val atH = c.downField(h)
-
-        atH.as(dv) match {
-          case Xor.Left(error) => Some(error)
-          case Xor.Right(value) => dk(h) match {
-            case None => Some(failure(atH.any))
-            case Some(k) =>
-              builder += (k -> value)
-              spinResult(t, c, builder)
-          }
-      }
-    }
-
-    @scala.annotation.tailrec
-    private[this] def spinAccumulating(
-      fields: List[String],
-      c: HCursor,
-      builder: Builder[(K, V), M[K, V]],
-      failed: Boolean,
-      errors: Builder[DecodingFailure, List[DecodingFailure]]
-    ): List[DecodingFailure] = fields match {
-      case Nil => errors.result
-      case h :: t =>
-        val atH = c.downField(h)
-
-        (atH.as(dv), dk(h)) match {
-          case (Xor.Left(error), _) => spinAccumulating(t, c, builder, true, errors += error)
-          case (_, None) => spinAccumulating(t, c, builder, true, errors += failure(atH.any))
-          case (Xor.Right(value), Some(k)) =>
-            if (!failed) {
-              builder += (k -> value)
-            } else ()
-
-            spinAccumulating(t, c, builder, failed, errors)
-        }
-    }
-  }
+  ): Decoder[M[K, V]] = new MapDecoder[M, K, V]
 
   /**
    * @group Decoding
@@ -677,69 +608,25 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final def decodeOneAnd[A, C[_]](implicit
     da: Decoder[A],
     cbf: CanBuildFrom[Nothing, A, C[A]]
-  ): Decoder[OneAnd[C, A]] = new Decoder[OneAnd[C, A]] {
-    def apply(c: HCursor): Result[OneAnd[C, A]] = {
-      val arr = c.downArray
-      for {
-        head <- da.tryDecode(arr)
-        tail <- decodeCanBuildFrom[A, C].tryDecode(arr.delete)
-      } yield OneAnd(head, tail)
-    }
-
-    override private[circe] def decodeAccumulating(
-      c: HCursor
-    ): AccumulatingDecoder.Result[OneAnd[C, A]] = {
-      val arr = c.downArray
-      val head = da.tryDecodeAccumulating(arr)
-      val tail = decodeCanBuildFrom[A, C].tryDecodeAccumulating(arr.delete)
-      tail.ap(head.map(h => (t: C[A]) => OneAnd(h, t)))
-    }
+  ): Decoder[OneAnd[C, A]] = new NonEmptySeqDecoder[A, C, OneAnd[C, A]] {
+    final protected val create: (A, C[A]) => OneAnd[C, A] = (h, t) => OneAnd(h, t)
   }
 
   /**
    * @group Decoding
    */
   implicit final def decodeNonEmptyList[A](implicit da: Decoder[A]): Decoder[NonEmptyList[A]] =
-    new Decoder[NonEmptyList[A]] {
-      def apply(c: HCursor): Result[NonEmptyList[A]] = {
-        val arr = c.downArray
-        for {
-          head <- da.tryDecode(arr)
-          tail <- decodeCanBuildFrom[A, List].tryDecode(arr.delete)
-        } yield NonEmptyList(head, tail)
-      }
-
-      override private[circe] def decodeAccumulating(
-        c: HCursor
-      ): AccumulatingDecoder.Result[NonEmptyList[A]] = {
-        val arr = c.downArray
-        val head = da.tryDecodeAccumulating(arr)
-        val tail = decodeCanBuildFrom[A, List].tryDecodeAccumulating(arr.delete)
-        tail.ap(head.map(h => (t: List[A]) => NonEmptyList(h, t)))
-      }
+    new NonEmptySeqDecoder[A, List, NonEmptyList[A]] {
+      final protected val create: (A, List[A]) => NonEmptyList[A] = (h, t) => NonEmptyList(h, t)
     }
 
   /**
    * @group Decoding
    */
   implicit final def decodeNonEmptyVector[A](implicit da: Decoder[A]): Decoder[NonEmptyVector[A]] =
-    new Decoder[NonEmptyVector[A]] {
-      def apply(c: HCursor): Result[NonEmptyVector[A]] = {
-        val arr = c.downArray
-        for {
-          head <- da.tryDecode(arr)
-          tail <- decodeCanBuildFrom[A, Vector].tryDecode(arr.delete)
-        } yield NonEmptyVector(head, tail)
-      }
-
-      override private[circe] def decodeAccumulating(
-        c: HCursor
-      ): AccumulatingDecoder.Result[NonEmptyVector[A]] = {
-        val arr = c.downArray
-        val head = da.tryDecodeAccumulating(arr)
-        val tail = decodeCanBuildFrom[A, Vector].tryDecodeAccumulating(arr.delete)
-        tail.ap(head.map(h => (t: Vector[A]) => NonEmptyVector(h, t)))
-      }
+    new NonEmptySeqDecoder[A, Vector, NonEmptyVector[A]] {
+      final protected val create: (A, Vector[A]) => NonEmptyVector[A] =
+        (h, t) => NonEmptyVector(h, t)
     }
 
   /**

--- a/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -230,6 +230,22 @@ object Encoder extends TupleEncoders with ProductEncoders with MidPriorityEncode
   /**
    * @group Encoding
    */
+  implicit final def encodeNonEmptyList[A](implicit e: Encoder[A]): Encoder[NonEmptyList[A]] =
+    new ArrayEncoder[NonEmptyList[A]] {
+      final def encodeArray(a: NonEmptyList[A]): List[Json] = a.toList.map(e(_))
+    }
+
+  /**
+   * @group Encoding
+   */
+  implicit final def encodeNonEmptyVector[A](implicit e: Encoder[A]): Encoder[NonEmptyVector[A]] =
+    new ArrayEncoder[NonEmptyVector[A]] {
+      final def encodeArray(a: NonEmptyVector[A]): List[Json] = a.toVector.toList.map(e(_))
+    }
+
+  /**
+   * @group Encoding
+   */
   implicit final def encodeOneAnd[A0, C[_]](
     implicit ea: Encoder[A0],
     is: IsTraversableOnce[C[A0]] { type A = A0 }

--- a/core/shared/src/main/scala/io/circe/Error.scala
+++ b/core/shared/src/main/scala/io/circe/Error.scala
@@ -2,7 +2,7 @@ package io.circe
 
 import cats.{ Eq, Show }
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 
 /**
  * The base exception type for both decoding and parsing errors.

--- a/core/shared/src/main/scala/io/circe/HCursor.scala
+++ b/core/shared/src/main/scala/io/circe/HCursor.scala
@@ -44,6 +44,7 @@ sealed abstract class HCursor(final val cursor: Cursor) extends GenericCursor[HC
    * This operation does not consume stack at each step, so is safe to work with
    * large structures (in contrast with recursively binding).
    */
+  @deprecated("No direct replacement", "0.6.0")
   final def traverseDecode[A](init: A)(
     op: HCursor => ACursor,
     f: (A, HCursor) => Decoder.Result[A]
@@ -84,6 +85,7 @@ sealed abstract class HCursor(final val cursor: Cursor) extends GenericCursor[HC
    * This operation does not consume stack at each step, so is safe to work with
    * large structures (in contrast with recursively binding).
    */
+  @deprecated("No direct replacement", "0.6.0")
   @tailrec final def traverseDecodeAccumulating[A](init: AccumulatingDecoder.Result[A])(
     op: HCursor => ACursor,
     f: (AccumulatingDecoder.Result[A], HCursor) => AccumulatingDecoder.Result[A]

--- a/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -2,7 +2,7 @@ package io.circe
 
 import cats.{ Applicative, Eq, Foldable, Show }
 import cats.data.Kleisli
-import cats.std.map._
+import cats.instances.map._
 import scala.collection.breakOut
 
 /**

--- a/core/shared/src/main/scala/io/circe/MapDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/MapDecoder.scala
@@ -1,0 +1,81 @@
+package io.circe
+
+import cats.data.{ NonEmptyList, Validated, Xor }
+import scala.annotation.tailrec
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable.Builder
+
+private[circe] final class MapDecoder[M[K, +V] <: Map[K, V], K, V](implicit
+  dk: KeyDecoder[K],
+  dv: Decoder[V],
+  cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]
+) extends Decoder[M[K, V]] {
+  def apply(c: HCursor): Decoder.Result[M[K, V]] = c.fields match {
+    case None => Xor.left[DecodingFailure, M[K, V]](MapDecoder.failure(c))
+    case Some(fields) =>
+      val builder = cbf()
+      spinResult(fields, c, builder) match {
+        case None => Xor.right(builder.result())
+        case Some(error) => Xor.left(error)
+      }
+  }
+
+  override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[M[K, V]] =
+    c.fields match {
+      case None => Validated.invalidNel(MapDecoder.failure(c))
+      case Some(fields) =>
+        val builder = cbf()
+        spinAccumulating(fields, c, builder, false, List.newBuilder[DecodingFailure]) match {
+          case Nil => Validated.valid(builder.result())
+          case error :: errors => Validated.invalid(NonEmptyList(error, errors))
+        }
+    }
+
+  @tailrec
+  private[this] def spinResult(
+    fields: List[String],
+    c: HCursor,
+    builder: Builder[(K, V), M[K, V]]
+  ): Option[DecodingFailure] = fields match {
+    case Nil => None
+    case h :: t =>
+      val atH = c.downField(h)
+
+      atH.as(dv) match {
+        case Xor.Left(error) => Some(error)
+        case Xor.Right(value) => dk(h) match {
+          case None => Some(MapDecoder.failure(atH.any))
+          case Some(k) =>
+            builder += (k -> value)
+            spinResult(t, c, builder)
+        }
+    }
+  }
+
+  @tailrec
+  private[this] def spinAccumulating(
+    fields: List[String],
+    c: HCursor,
+    builder: Builder[(K, V), M[K, V]],
+    failed: Boolean,
+    errors: Builder[DecodingFailure, List[DecodingFailure]]
+  ): List[DecodingFailure] = fields match {
+    case Nil => errors.result
+    case h :: t =>
+      val atH = c.downField(h)
+
+      (atH.as(dv), dk(h)) match {
+        case (Xor.Left(error), _) => spinAccumulating(t, c, builder, true, errors += error)
+        case (_, None) =>
+          spinAccumulating(t, c, builder, true, errors += MapDecoder.failure(atH.any))
+        case (Xor.Right(value), Some(k)) =>
+          if (!failed) builder += (k -> value)
+
+          spinAccumulating(t, c, builder, failed, errors)
+      }
+  }
+}
+
+private[circe] final object MapDecoder {
+  def failure(c: HCursor): DecodingFailure = DecodingFailure("[K, V]Map[K, V]", c.history)
+}

--- a/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
@@ -1,0 +1,32 @@
+package io.circe
+
+import scala.collection.generic.CanBuildFrom
+
+private[circe] abstract class NonEmptySeqDecoder[A, C[_], S](implicit
+  decodeA: Decoder[A],
+  cbf: CanBuildFrom[Nothing, A, C[A]]
+) extends Decoder[S] {
+  protected def create: (A, C[A]) => S
+  private[this] final val decodeCA: Decoder[C[A]] = Decoder.decodeCanBuildFrom[A, C](decodeA, cbf)
+
+  final def apply(c: HCursor): Decoder.Result[S] = {
+    val arr = c.downArray
+
+    decodeA.tryDecode(arr).flatMap { head =>
+      decodeCA.tryDecode(arr.delete).map { tail =>
+        create(head, tail)
+      }
+    }
+  }
+
+  override final private[circe] def decodeAccumulating(
+    c: HCursor
+  ): AccumulatingDecoder.Result[S] = {
+    val arr = c.downArray
+
+    AccumulatingDecoder.resultInstance.map2(
+      decodeA.tryDecodeAccumulating(arr),
+      decodeCA.tryDecodeAccumulating(arr.delete)
+    )(create)
+  }
+}

--- a/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/core/shared/src/main/scala/io/circe/Parser.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.data.{ OneAnd, Validated, ValidatedNel, Xor }
+import cats.data.{ NonEmptyList, Validated, ValidatedNel, Xor }
 
 trait Parser extends Serializable {
   def parse(input: String): Xor[ParsingFailure, Json]
@@ -11,7 +11,7 @@ trait Parser extends Serializable {
   final def decodeAccumulating[A](input: String)(implicit decoder: Decoder[A]): ValidatedNel[Error, A] =
     parse(input) match {
       case Xor.Right(json) => decoder.accumulating(json.hcursor).leftMap {
-        case OneAnd(h, t) => OneAnd(h, t)
+        case NonEmptyList(h, t) => NonEmptyList(h, t)
       }
       case Xor.Left(error) => Validated.invalidNel(error)
     }

--- a/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -1,0 +1,60 @@
+package io.circe
+
+import cats.data.{ NonEmptyList, Validated, Xor }
+import scala.collection.generic.CanBuildFrom
+
+private[circe] class SeqDecoder[A, C[_]](
+  decodeA: Decoder[A],
+  cbf: CanBuildFrom[Nothing, A, C[A]]
+) extends Decoder[C[A]] {
+  final def apply(c: HCursor): Decoder.Result[C[A]] = {
+    var current = c.downArray
+
+    if (current.succeeded) {
+      val builder = cbf.apply
+      var failed: DecodingFailure = null
+
+      while (failed.eq(null) && current.succeeded) {
+        decodeA(current.any) match {
+          case Xor.Left(e) => failed = e
+          case Xor.Right(a) =>
+            builder += a
+            current = current.right
+        }
+      }
+
+      if (failed.eq(null)) Xor.right(builder.result) else Xor.left(failed)
+    } else {
+      Xor.left(DecodingFailure("CanBuildFrom for A", c.history))
+    }
+  }
+
+  override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[C[A]] = {
+    var current = c.downArray
+
+    if (current.succeeded) {
+      val builder = cbf.apply
+      var failed = false
+      val failures = List.newBuilder[DecodingFailure]
+
+      while (current.succeeded) {
+        decodeA.decodeAccumulating(current.any) match {
+          case Validated.Invalid(es) =>
+            failed = true
+            failures += es.head
+            failures ++= es.tail
+          case Validated.Valid(a) =>
+            if (!failed) builder += a
+            current = current.right
+        }
+      }
+
+      failures.result match {
+        case Nil => Validated.valid(builder.result)
+        case h :: t => Validated.invalid(NonEmptyList(h, t))
+      }
+    } else {
+      Validated.invalidNel(DecodingFailure("CanBuildFrom for A", c.history))
+    }
+  }
+}

--- a/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -45,8 +45,8 @@ private[circe] class SeqDecoder[A, C[_]](
             failures ++= es.tail
           case Validated.Valid(a) =>
             if (!failed) builder += a
-            current = current.right
         }
+        current = current.right
       }
 
       failures.result match {

--- a/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -1,6 +1,6 @@
 package io.circe.optics
 
-import cats.std.list.{ listInstance => catsListInstance }
+import cats.instances.list.catsStdInstancesForList
 import io.circe.{ Json, JsonObject }
 import monocle.{ Lens, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
@@ -41,7 +41,7 @@ trait JsonObjectOptics extends CatsConversions with ListInstances {
               case (field, json) =>
                 F.map(if (p(field)) f(json) else F.point(json))(field -> _)
             }
-          )(JsonObject.from(_)(catsListInstance))
+          )(JsonObject.from(_)(catsStdInstancesForList))
     }
   }
 

--- a/optics/src/main/scala/io/circe/optics/JsonOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonOptics.scala
@@ -1,6 +1,6 @@
 package io.circe.optics
 
-import cats.std.list._
+import cats.instances.list._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import io.circe.{ Json, JsonNumber, JsonObject }

--- a/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
+++ b/streaming/src/main/scala/io/circe/streaming/ParsingEnumeratee.scala
@@ -2,8 +2,8 @@ package io.circe.streaming
 
 import _root_.jawn.{ AsyncParser, ParseException }
 import cats.ApplicativeError
-import cats.std.either._
-import cats.std.vector._
+import cats.instances.either._
+import cats.instances.vector._
 import cats.syntax.traverse._
 import io.circe.{ Json, ParsingFailure }
 import io.circe.jawn.CirceSupportParser

--- a/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.tests
 
-import cats.std.AllInstances
+import cats.instances.AllInstances
 import cats.syntax.AllSyntax
 import org.scalatest.FlatSpec
 import org.scalatest.prop.{ Checkers, GeneratorDrivenPropertyChecks }

--- a/tests/shared/src/main/scala/io/circe/tests/EqInstances.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/EqInstances.scala
@@ -1,7 +1,6 @@
 package io.circe.tests
 
 import cats.Eq
-import cats.std.list._
 import cats.syntax.eq._
 import io.circe.{ AccumulatingDecoder, Decoder, Encoder, Json }
 import org.scalacheck.Arbitrary

--- a/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
@@ -22,10 +22,10 @@ case class ParserTests(p: Parser) extends Laws {
     name = "parser",
     parent = None,
     "roundTripWithoutSpaces" -> Prop.forAll { (json: Json) =>
-      isEqToProp(laws.parsingRoundTripNoSpaces(json))
+      laws.parsingRoundTripNoSpaces(json)
     },
     "roundTripWithSpaces" -> Prop.forAll { (json: Json) =>
-      isEqToProp(laws.parsingRoundTripSpaces(json))
+      laws.parsingRoundTripSpaces(json)
     }
   )
 }

--- a/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
@@ -1,9 +1,9 @@
 package io.circe.tests
 
 import cats.Eq
+import cats.instances.option._
 import cats.laws._
 import cats.laws.discipline._
-import cats.std.option._
 import io.circe.{ Decoder, Encoder, Parser, Printer }
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
@@ -36,7 +36,7 @@ trait PrinterTests[A] extends Laws {
       name = "printer",
       parent = None,
       "roundTrip" -> Prop.forAll { (a: A) =>
-        isEqToProp(laws.printerRoundTrip(printer, parser, a))
+        laws.printerRoundTrip(printer, parser, a)
       }
     )
 }

--- a/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
+++ b/tests/shared/src/main/scala/io/circe/tests/examples/package.scala
@@ -1,7 +1,7 @@
 package io.circe.tests
 
 import cats.Eq
-import cats.std.AllInstances
+import cats.instances.AllInstances
 import io.circe.{ Decoder, Encoder, Json }
 import org.scalacheck.{ Arbitrary, Gen }
 

--- a/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -12,7 +12,7 @@ class AnyValCodecSuite extends CirceSuite {
    * from itself.
    */
   val eqFloat: Eq[Float] = Eq.instance { (a, b) =>
-    (a.isNaN && b.isNaN) || cats.std.float.floatOrder.eqv(a, b)
+    (a.isNaN && b.isNaN) || cats.instances.float.catsKernelStdOrderForFloat.eqv(a, b)
   }
 
   /**
@@ -20,7 +20,7 @@ class AnyValCodecSuite extends CirceSuite {
    * from itself.
    */
   val eqDouble: Eq[Double] = Eq.instance { (a, b) =>
-    (a.isNaN && b.isNaN) || cats.std.double.doubleOrder.eqv(a, b)
+    (a.isNaN && b.isNaN) || cats.instances.double.catsKernelStdOrderForDouble.eqv(a, b)
   }
 
   checkLaws("Codec[Unit]", CodecTests[Unit].codec)

--- a/tests/shared/src/test/scala/io/circe/CursorSuites.scala
+++ b/tests/shared/src/test/scala/io/circe/CursorSuites.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.std.list._
+import cats.instances.list._
 import io.circe.tests.CursorSuite
 
 class BasicCursorSuite extends CursorSuite[Cursor] {

--- a/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/generic/JsonCodecMacrosSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.generic
 
 import cats.Eq
-import cats.std.AllInstances
+import cats.instances.AllInstances
 import io.circe.ObjectEncoder
 import io.circe.generic.jsoncodecmacrossuiteaux._
 import io.circe.tests.{ ArbitraryInstances, CirceSuite, CodecTests, MissingInstances }


### PR DESCRIPTION
The changes here have two motivations: to clean up `Decoder.scala` by defining helper classes for map and sequence decoders (which also allows us to avoid duplicating some logic), and to improve performance by replacing a bunch of unpleasant functional code with unpleasant imperative code.

The API and behavior are unchanged (apart from one minor detail about the order of errors when using error accumulation with maps, in which case the previous behavior was arguably less intuitive), and none of the newly introduced mutability or imperativity faces the outside world.

The performance gains surprised me a bit—throughput is around 35% higher for our map-focused benchmark, and 8% for arrays of integers:

```
decodeFoosC     thrpt   20   3312.674 ±   27.015  ops/s (before)
decodeFoosC     thrpt   20   4513.516 ±  163.341  ops/s (after)

decodeIntsC     thrpt   20  19639.295 ±  164.289  ops/s (before)
decodeIntsC     thrpt   20  21266.008 ±  109.671  ops/s (after)
```

And allocation rates are around 25% lower:

```
decodeFoosC:gc.alloc.rate.norm  thrpt  5  1193152.347 ±   0.005  B/op (before)
decodeFoosC:gc.alloc.rate.norm  thrpt  5   888800.267 ±   0.003  B/op (after)

decodeIntsC:gc.alloc.rate.norm  thrpt  5   275359.804 ±  61.666  B/op (before)
decodeIntsC:gc.alloc.rate.norm  thrpt  5   203237.521 ±  47.057  B/op (after)
```

Most of these gains are due to the fact that we're not constructing extra `Xor` or `Option` values for every element we successfully decode.

Note that I'm deprecating `traverseDecode` and `traverseDecodeAccumulating` on `HCursor`, but I may remove them entirely before the 0.5.0 release—I don't think anyone else is likely to be using them.

This PR depends on #337—I'll rebase it and get rid of the snapshot dependencies once the new versions of Cats and iteratee.io are published.