### PR TITLE
Add circe-scodec subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,7 @@ def noDocProjects(sv: String): Seq[ProjectReference] = Seq[ProjectReference](
   numbersJS,
   parserJS,
   refinedJS,
+  scodecJS,
   tests,
   testsJS
 ) ++ (
@@ -109,6 +110,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   literal, literalJS,
   refined, refinedJS,
   parser, parserJS,
+  scodec, scodecJS,
   tests, testsJS,
   jawn,
   jackson,
@@ -289,6 +291,24 @@ lazy val scalajs = project
   .enablePlugins(ScalaJSPlugin)
   .dependsOn(coreJS)
 
+lazy val scodecBase = crossProject.in(file("scodec"))
+  .settings(
+    description := "circe scodec",
+    moduleName := "circe-scodec",
+    name := "scodec"
+  )
+  .settings(allSettings: _*)
+  .settings(
+    libraryDependencies += "org.scodec" %% "scodec-bits" % "1.1.0"
+  )
+  .jsSettings(commonJsSettings: _*)
+  .jvmConfigure(_.copy(id = "scodec"))
+  .jsConfigure(_.copy(id = "scodecJS"))
+  .dependsOn(coreBase)
+
+lazy val scodec = scodecBase.jvm
+lazy val scodecJS = scodecBase.js
+
 lazy val testsBase = crossProject.in(file("tests"))
   .settings(
     description := "circe tests",
@@ -328,7 +348,8 @@ lazy val testsBase = crossProject.in(file("tests"))
     genericBase,
     literalBase,
     refinedBase,
-    parserBase
+    parserBase,
+    scodecBase
   )
 
 lazy val tests = testsBase.jvm
@@ -539,6 +560,7 @@ val jvmProjects = Seq(
   "generic",
   "refined",
   "parser",
+  "scodec",
   "tests",
   "jawn",
   "jackson",
@@ -564,6 +586,7 @@ val jsProjects = Seq(
   "refinedJS",
   "parserJS",
   "scalajs",
+  "scodecJS",
   "testsJS"
 )
 

--- a/scodec/shared/src/main/scala/io/circe/scodec.scala
+++ b/scodec/shared/src/main/scala/io/circe/scodec.scala
@@ -4,7 +4,7 @@ import _root_.scodec.bits.{BitVector, ByteVector}
 import cats.data.Xor
 
 package object scodec {
-  implicit final val bitVectorDecoder: Decoder[BitVector] =
+  implicit final val decodeBitVector: Decoder[BitVector] =
     Decoder.instance { c =>
       Decoder.decodeString(c).flatMap { str =>
         BitVector.fromBase64Descriptive(str) match {
@@ -14,10 +14,10 @@ package object scodec {
       }
     }
 
-  implicit final val bitVectorEncoder: Encoder[BitVector] =
+  implicit final val encodeBitVector: Encoder[BitVector] =
     Encoder.encodeString.contramap(_.toBase64)
 
-  implicit final val byteVectorDecoder: Decoder[ByteVector] =
+  implicit final val decodeByteVector: Decoder[ByteVector] =
     Decoder.instance { c =>
       Decoder.decodeString(c).flatMap { str =>
         ByteVector.fromBase64Descriptive(str) match {
@@ -27,6 +27,6 @@ package object scodec {
       }
     }
 
-  implicit final val byteVectorEncoder: Encoder[ByteVector] =
+  implicit final val encodeByteVector: Encoder[ByteVector] =
     Encoder.encodeString.contramap(_.toBase64)
 }

--- a/scodec/shared/src/main/scala/io/circe/scodec.scala
+++ b/scodec/shared/src/main/scala/io/circe/scodec.scala
@@ -1,0 +1,32 @@
+package io.circe
+
+import _root_.scodec.bits.{BitVector, ByteVector}
+import cats.data.Xor
+
+package object scodec {
+  implicit final val bitVectorDecoder: Decoder[BitVector] =
+    Decoder.instance { c =>
+      Decoder.decodeString(c).flatMap { str =>
+        BitVector.fromBase64Descriptive(str) match {
+          case Right(bits) => Xor.right(bits)
+          case Left(err) => Xor.left(DecodingFailure(err, c.history))
+        }
+      }
+    }
+
+  implicit final val bitVectorEncoder: Encoder[BitVector] =
+    Encoder.encodeString.contramap(_.toBase64)
+
+  implicit final val byteVectorDecoder: Decoder[ByteVector] =
+    Decoder.instance { c =>
+      Decoder.decodeString(c).flatMap { str =>
+        ByteVector.fromBase64Descriptive(str) match {
+          case Right(bytes) => Xor.right(bytes)
+          case Left(err) => Xor.left(DecodingFailure(err, c.history))
+        }
+      }
+    }
+
+  implicit final val byteVectorEncoder: Encoder[ByteVector] =
+    Encoder.encodeString.contramap(_.toBase64)
+}

--- a/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
+++ b/tests/shared/src/test/scala/io/circe/scodec/ScodecSuite.scala
@@ -1,0 +1,24 @@
+package io.circe.scodec
+
+import _root_.scodec.bits.{BitVector, ByteVector}
+import cats.Eq
+import io.circe.tests.{CirceSuite, CodecTests}
+import org.scalacheck.Arbitrary
+
+class ScodecSuite extends CirceSuite {
+  implicit val arbitraryBitVector: Arbitrary[BitVector] =
+    Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(BitVector.view))
+
+  implicit val arbitraryByteVector: Arbitrary[ByteVector] =
+    Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(ByteVector.view))
+
+  implicit val eqBitVector: Eq[BitVector] =
+    Eq.fromUniversalEquals
+
+  implicit val eqByteVector: Eq[ByteVector] =
+    Eq.fromUniversalEquals
+
+  checkLaws("Codec[BitVector]", CodecTests[BitVector].codec)
+  
+  checkLaws("Codec[ByteVector]", CodecTests[ByteVector].codec)
+}


### PR DESCRIPTION
circe-scodec provides `Decoder` and `Encoder` instances for
scodec-bits' `BitVector` and `ByteVecor` using Base64 for
serialization.

Example:
```scala
scala> import io.circe._, io.circe.generic.auto._, io.circe.parser._,
io.circe.syntax._, io.circe.scodec._
import io.circe._
import io.circe.generic.auto._
import io.circe.parser._
import io.circe.syntax._
import io.circe.scodec._

scala> import _root_.scodec.bits.ByteVector
import _root_.scodec.bits.ByteVector

scala> case class Foo(bytes: ByteVector)
defined class Foo

scala> val foo = Foo(ByteVector.view("Hello world!".getBytes))
foo: Foo = Foo(ByteVector(12 bytes, 0x48656c6c6f20776f726c6421))

scala> foo.asJson.noSpaces
res0: String = {"bytes":"SGVsbG8gd29ybGQh"}

scala> decode[Foo](res0)
res1: cats.data.Xor[io.circe.Error,Foo] = Right(Foo(ByteVector(12 bytes,
0x48656c6c6f20776f726c6421)))
```
/cc @mpilquist