### PR TITLE
Replace Xor

### DIFF
--- a/modules/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
+++ b/modules/benchmark/src/main/scala/io/circe/benchmark/Benchmark.scala
@@ -122,7 +122,7 @@ class EncodingBenchmark extends ExampleData {
 @OutputTimeUnit(TimeUnit.SECONDS)
 class DecodingBenchmark extends ExampleData {
   @Benchmark
-  def decodeIntsC: List[Int] = intsC.as[List[Int]].getOrElse(throw new Exception)
+  def decodeIntsC: List[Int] = intsC.as[List[Int]].right.getOrElse(throw new Exception)
 
   @Benchmark
   def decodeIntsA: List[Int] = intsA.as[List[Int]].result.getOrElse(throw new Exception)
@@ -138,7 +138,7 @@ class DecodingBenchmark extends ExampleData {
 
   @Benchmark
   def decodeFoosC: Map[String, Foo] =
-    foosC.as[Map[String, Foo]].getOrElse(throw new Exception)
+    foosC.as[Map[String, Foo]].right.getOrElse(throw new Exception)
 
   @Benchmark
   def decodeFoosA: Map[String, Foo] =
@@ -166,10 +166,10 @@ class DecodingBenchmark extends ExampleData {
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ParsingBenchmark extends ExampleData {
   @Benchmark
-  def parseIntsC: JsonC = parse(intsJson).getOrElse(throw new Exception)
+  def parseIntsC: JsonC = parse(intsJson).right.getOrElse(throw new Exception)
 
   @Benchmark
-  def parseIntsCJ: JsonC = io.circe.jackson.parse(intsJson).getOrElse(throw new Exception)
+  def parseIntsCJ: JsonC = io.circe.jackson.parse(intsJson).right.getOrElse(throw new Exception)
 
   @Benchmark
   def parseIntsA: JsonA = Parse.parse(intsJson).getOrElse(throw new Exception)
@@ -184,10 +184,10 @@ class ParsingBenchmark extends ExampleData {
   def parseIntsPico: backend.BValue = readAst(intsJson)
 
   @Benchmark
-  def parseFoosC: JsonC = parse(foosJson).getOrElse(throw new Exception)
+  def parseFoosC: JsonC = parse(foosJson).right.getOrElse(throw new Exception)
 
   @Benchmark
-  def parseFoosCJ: JsonC = io.circe.jackson.parse(foosJson).getOrElse(throw new Exception)
+  def parseFoosCJ: JsonC = io.circe.jackson.parse(foosJson).right.getOrElse(throw new Exception)
 
   @Benchmark
   def parseFoosA: JsonA = Parse.parse(foosJson).getOrElse(throw new Exception)
@@ -268,11 +268,11 @@ class CirceDerivationBenchmark {
 
   private[this] val nonDerivedDecoder: Decoder[Foo] = new Decoder[Foo] {
     def apply(c: HCursor): Decoder.Result[Foo] = for {
-      s <- c.get[String]("s")
-      d <- c.get[Double]("d")
-      i <- c.get[Int]("i")
-      l <- c.get[Long]("l")
-      bs <- c.get[List[Boolean]]("bs")
+      s <- c.get[String]("s").right
+      d <- c.get[Double]("d").right
+      i <- c.get[Int]("i").right
+      l <- c.get[Long]("l").right
+      bs <- c.get[List[Boolean]]("bs").right
     } yield Foo(s, d, i, l, bs)
   }
 

--- a/modules/benchmark/src/test/scala/io/circe/benchmark/CirceDerivationBenchmarkSpec.scala
+++ b/modules/benchmark/src/test/scala/io/circe/benchmark/CirceDerivationBenchmarkSpec.scala
@@ -1,6 +1,5 @@
 package io.circe.benchmark
 
-import cats.data.Xor
 import org.scalatest.FlatSpec
 
 class CirceDerivationBenchmarkSpec extends FlatSpec {
@@ -9,7 +8,7 @@ class CirceDerivationBenchmarkSpec extends FlatSpec {
   import benchmark._
 
   "The derived codecs" should "correctly decode Foos" in {
-    assert(decodeDerived === Xor.right(exampleFoo))
+    assert(decodeDerived === Right(exampleFoo))
   }
 
   it should "correctly encode Foos" in {
@@ -17,7 +16,7 @@ class CirceDerivationBenchmarkSpec extends FlatSpec {
   }
 
   "The non-derived codecs" should "correctly decode Foos" in {
-    assert(decodeNonDerived === Xor.right(exampleFoo))
+    assert(decodeNonDerived === Right(exampleFoo))
   }
 
   it should "correctly encode Foos" in {

--- a/modules/core/shared/src/main/scala/io/circe/ACursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/ACursor.scala
@@ -1,7 +1,8 @@
 package io.circe
 
 import cats.{ Applicative, Eq }
-import cats.data.{ Validated, Xor }
+import cats.data.Validated
+import cats.instances.either._
 
 /**
  * A cursor that tracks history and represents the possibility of failure.
@@ -17,7 +18,7 @@ sealed abstract class ACursor(final val any: HCursor) extends GenericCursor[ACur
   type Result = ACursor
   type M[x[_]] = Applicative[x]
 
-  final def either: Xor[HCursor, HCursor] = if (succeeded) Xor.right(any) else Xor.left(any)
+  final def either: Either[HCursor, HCursor] = if (succeeded) Right(any) else Left(any)
 
   /**
    * Return the current [[HCursor]] if we are in a success state.
@@ -69,7 +70,7 @@ sealed abstract class ACursor(final val any: HCursor) extends GenericCursor[ACur
   /**
    * Return a [[cats.data.Validated]] of the underlying cursor.
    */
-  final def validation: Validated[HCursor, HCursor] = either.toValidated
+  final def validation: Validated[HCursor, HCursor] = Validated.fromEither(either)
 
   /**
    * A helper method to simplify performing operations on the underlying [[HCursor]].

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -14,13 +14,15 @@ trait Decoder[A] extends Serializable { self =>
    */
   def apply(c: HCursor): Decoder.Result[A]
 
-  private[circe] def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
-    apply(c).toValidated.toValidatedNel
+  private[circe] def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] = apply(c) match {
+    case Right(a) => Validated.valid(a)
+    case Left(e) => Validated.invalidNel(e)
+  }
 
   /**
    * Decode the given acursor.
    */
-  def tryDecode(c: ACursor): Decoder.Result[A] = if (c.succeeded) apply(c.any) else Xor.left(
+  def tryDecode(c: ACursor): Decoder.Result[A] = if (c.succeeded) apply(c.any) else Left(
     DecodingFailure("Attempt to decode value on failed cursor", c.any.history)
   )
 
@@ -41,16 +43,14 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def map[B](f: A => B): Decoder[B] = new Decoder[B] {
     final def apply(c: HCursor): Decoder.Result[B] = self(c) match {
-      case Xor.Right(a) => Xor.Right(f(a))
-      case l @ Xor.Left(_) => l
+      case Right(a) => Right(f(a))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
     }
-
-    override final def tryDecode(c: ACursor): Decoder.Result[B] = self.tryDecode(c) match {
-      case Xor.Right(a) => Xor.Right(f(a))
-      case l @ Xor.Left(_) => l
+    override def tryDecode(c: ACursor): Decoder.Result[B] = self.tryDecode(c) match {
+      case Right(a) => Right(f(a))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
     }
-
-    override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[B] =
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[B] =
       self.decodeAccumulating(c).map(f)
   }
 
@@ -59,13 +59,13 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def flatMap[B](f: A => Decoder[B]): Decoder[B] = new Decoder[B] {
     final def apply(c: HCursor): Decoder.Result[B] = self(c) match {
-      case Xor.Right(a) => f(a)(c)
-      case l @ Xor.Left(_) => l
+      case Right(a) => f(a)(c)
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
     }
 
-    override final def tryDecode(c: ACursor): Decoder.Result[B] = self.tryDecode(c) match {
-      case Xor.Right(a) => f(a).tryDecode(c)
-      case l @ Xor.Left(_) => l
+    override def tryDecode(c: ACursor): Decoder.Result[B] = self.tryDecode(c) match {
+      case Right(a) => f(a).tryDecode(c)
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
     }
 
     override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[B] =
@@ -93,7 +93,10 @@ trait Decoder[A] extends Serializable { self =>
    * Build a new instance with the specified error message.
    */
   final def withErrorMessage(message: String): Decoder[A] = new Decoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = self(c).leftMap(_.withMessage(message))
+    final def apply(c: HCursor): Decoder.Result[A] = self(c) match {
+      case r @ Right(_) => r
+      case Left(e) => Left(e.withMessage(message))
+    }
 
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       self.decodeAccumulating(c).leftMap(_.map(_.withMessage(message)))
@@ -104,7 +107,7 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] =
-      if (pred(c)) apply(c) else Xor.left(DecodingFailure(message, c.history))
+      if (pred(c)) apply(c) else Left(DecodingFailure(message, c.history))
   }
 
   /**
@@ -127,17 +130,23 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def or[AA >: A](d: => Decoder[AA]): Decoder[AA] = new Decoder[AA] {
     final def apply(c: HCursor): Decoder.Result[AA] = self(c) match {
-      case r @ Xor.Right(_) => r
-      case Xor.Left(_) => d(c)
+      case r @ Right(_) => r
+      case Left(_) => d(c)
     }
   }
 
   /**
    * Run one or another decoder.
    */
-  final def split[B](d: Decoder[B]): Xor[HCursor, HCursor] => Decoder.Result[Xor[A, B]] = _ match {
-    case Xor.Left(c) => self(c).map(Xor.left)
-    case Xor.Right(c) => d(c).map(Xor.right)
+  final def split[B](d: Decoder[B]): Either[HCursor, HCursor] => Decoder.Result[Either[A, B]] = _ match {
+    case Left(c) => self(c) match {
+      case Right(v) => Right(Left(v))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[Either[A, B]]]
+    }
+    case Right(c) => d(c) match {
+      case Right(v) => Right(Right(v))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[Either[A, B]]]
+    }
   }
 
   /**
@@ -160,9 +169,15 @@ trait Decoder[A] extends Serializable { self =>
    *
    * @param f a function returning either a value or an error message
    */
-  final def emap[B](f: A => Xor[String, B]): Decoder[B] = new Decoder[B] {
+  final def emap[B](f: A => Either[String, B]): Decoder[B] = new Decoder[B] {
     final def apply(c: HCursor): Decoder.Result[B] =
-      self(c).flatMap(a => f(a).leftMap(message => DecodingFailure(message, c.history)))
+      self(c) match {
+        case Right(a) => f(a) match {
+          case r @ Right(_) => r.asInstanceOf[Decoder.Result[B]]
+          case Left(message) => Left(DecodingFailure(message, c.history))
+        }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
+      }
   }
   /**
    * Create a new decoder that performs some operation on the result if this one succeeds.
@@ -171,11 +186,12 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def emapTry[B](f: A => Try[B]): Decoder[B] = new Decoder[B] {
     final def apply(c: HCursor): Decoder.Result[B] =
-      self(c).flatMap { a =>
-        f(a) match {
-          case Success(b) => Xor.right(b)
-          case Failure(t) => Xor.left(DecodingFailure.fromThrowable(t, c.history))
+      self(c) match {
+        case Right(a) => f(a) match {
+          case Success(b) => Right(b)
+          case Failure(t) => Left(DecodingFailure.fromThrowable(t, c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
       }
   }
 }
@@ -213,13 +229,28 @@ trait Decoder[A] extends Serializable { self =>
 final object Decoder extends TupleDecoders with ProductDecoders with LowPriorityDecoders {
   import Json._
 
-  type Result[A] = Xor[DecodingFailure, A]
+  type Result[A] = Either[DecodingFailure, A]
 
-  val resultInstance: MonadError[Result, DecodingFailure] =
-    Xor.catsDataInstancesForXor[DecodingFailure]
+  val resultInstance: MonadError[Result, DecodingFailure] = new MonadError[Result, DecodingFailure] {
+    final def pure[A](x: A): Decoder.Result[A] = Right(x)
+    override final def map[A, B](fa: Decoder.Result[A])(f: A => B): Decoder.Result[B] = fa match {
+      case Right(a) => Right(f(a))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
+    }
+    final def flatMap[A, B](fa: Decoder.Result[A])(f: A => Decoder.Result[B]): Decoder.Result[B] = fa match {
+      case Right(a) => f(a)
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[B]]
+    }
+    final def raiseError[A](e: DecodingFailure): Decoder.Result[A] = Left(e)
+    final def handleErrorWith[A](fa: Decoder.Result[A])(f: DecodingFailure => Decoder.Result[A]): Decoder.Result[A] =
+      fa match {
+        case r @ Right(_) => r
+        case Left(e) => f(e)
+      }
+  }
 
   private[this] abstract class DecoderWithFailure[A](name: String) extends Decoder[A] {
-    final def fail(c: HCursor): Result[A] = Xor.left(DecodingFailure(name, c.history))
+    final def fail(c: HCursor): Result[A] = Left(DecodingFailure(name, c.history))
   }
 
   /**
@@ -233,7 +264,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * Create a decoder that always returns a single value, useful with some flatMap situations
    */
   final def const[A](a: A): Decoder[A] = new Decoder[A] {
-    final def apply(c: HCursor): Result[A] = Xor.right(a)
+    final def apply(c: HCursor): Result[A] = Right(a)
     final override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       Validated.valid(a)
   }
@@ -253,8 +284,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   final def instanceTry[A](f: HCursor => Try[A]): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Result[A] = f(c) match {
-      case Success(a) => Xor.right(a)
-      case Failure(t) => Xor.left(DecodingFailure.fromThrowable(t, c.history))
+      case Success(a) => Right(a)
+      case Failure(t) => Left(DecodingFailure.fromThrowable(t, c.history))
     }
   }
 
@@ -271,8 +302,10 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       tryDecodeAccumulating(c.acursor)
 
-    override def tryDecodeAccumulating(c: ACursor): AccumulatingDecoder.Result[A] =
-      f(c).toValidated.toValidatedNel
+    override def tryDecodeAccumulating(c: ACursor): AccumulatingDecoder.Result[A] = f(c) match {
+      case Right(v) => Validated.valid(v)
+      case Left(e) => Validated.invalidNel(e)
+    }
   }
 
   /**
@@ -281,7 +314,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Utilities
    */
   final def failed[A](failure: DecodingFailure): Decoder[A] = new Decoder[A] {
-    final def apply(c: HCursor): Result[A] = Xor.left(failure)
+    final def apply(c: HCursor): Result[A] = Left(failure)
     override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       Validated.invalidNel(failure)
   }
@@ -297,14 +330,14 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Decoding
    */
   implicit final val decodeHCursor: Decoder[HCursor] = new Decoder[HCursor] {
-    final def apply(c: HCursor): Result[HCursor] = Xor.right(c)
+    final def apply(c: HCursor): Result[HCursor] = Right(c)
   }
 
   /**
    * @group Decoding
    */
   implicit final val decodeJson: Decoder[Json] = new Decoder[Json] {
-    final def apply(c: HCursor): Result[Json] = Xor.right(c.focus)
+    final def apply(c: HCursor): Result[Json] = Right(c.focus)
   }
 
   /**
@@ -312,8 +345,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeJsonObject: Decoder[JsonObject] = new Decoder[JsonObject] {
     final def apply(c: HCursor): Result[JsonObject] = c.focus.asObject match {
-      case Some(v) => Xor.right(v)
-      case None => Xor.left(DecodingFailure("JsonObject", c.history))
+      case Some(v) => Right(v)
+      case None => Left(DecodingFailure("JsonObject", c.history))
     }
   }
 
@@ -322,8 +355,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeJsonNumber: Decoder[JsonNumber] = new Decoder[JsonNumber] {
     final def apply(c: HCursor): Result[JsonNumber] = c.focus.asNumber match {
-      case Some(v) => Xor.right(v)
-      case None => Xor.left(DecodingFailure("JsonNumber", c.history))
+      case Some(v) => Right(v)
+      case None => Left(DecodingFailure("JsonNumber", c.history))
     }
   }
 
@@ -332,8 +365,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeString: Decoder[String] = new Decoder[String] {
     final def apply(c: HCursor): Result[String] = c.focus match {
-      case JString(string) => Xor.right(string)
-      case _ => Xor.left(DecodingFailure("String", c.history))
+      case JString(string) => Right(string)
+      case _ => Left(DecodingFailure("String", c.history))
     }
   }
 
@@ -342,10 +375,10 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeUnit: Decoder[Unit] = new Decoder[Unit] {
     final def apply(c: HCursor): Result[Unit] = c.focus match {
-      case JNull => Xor.right(())
-      case JObject(obj) if obj.isEmpty => Xor.right(())
-      case JArray(arr) if arr.isEmpty => Xor.right(())
-      case _ => Xor.left(DecodingFailure("Unit", c.history))
+      case JNull => Right(())
+      case JObject(obj) if obj.isEmpty => Right(())
+      case JArray(arr) if arr.isEmpty => Right(())
+      case _ => Left(DecodingFailure("Unit", c.history))
     }
   }
 
@@ -354,8 +387,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeBoolean: Decoder[Boolean] = new Decoder[Boolean] {
     final def apply(c: HCursor): Result[Boolean] = c.focus match {
-      case JBoolean(b) => Xor.right(b)
-      case _ => Xor.left(DecodingFailure("Boolean", c.history))
+      case JBoolean(b) => Right(b)
+      case _ => Left(DecodingFailure("Boolean", c.history))
     }
   }
 
@@ -364,8 +397,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeChar: Decoder[Char] = new Decoder[Char] {
     final def apply(c: HCursor): Result[Char] = c.focus match {
-      case JString(string) if string.length == 1 => Xor.right(string.charAt(0))
-      case _ => Xor.left(DecodingFailure("Char", c.history))
+      case JString(string) if string.length == 1 => Right(string.charAt(0))
+      case _ => Left(DecodingFailure("Char", c.history))
     }
   }
 
@@ -378,10 +411,10 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeFloat: Decoder[Float] = new DecoderWithFailure[Float]("Float") {
     final def apply(c: HCursor): Result[Float] = c.focus match {
-      case JNull => Xor.right(Float.NaN)
-      case JNumber(number) => Xor.right(number.toDouble.toFloat)
+      case JNull => Right(Float.NaN)
+      case JNumber(number) => Right(number.toDouble.toFloat)
       case JString(string) => JsonNumber.fromString(string).map(_.toDouble.toFloat) match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case _ => fail(c)
@@ -399,10 +432,10 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    */
   implicit final val decodeDouble: Decoder[Double] = new DecoderWithFailure[Double]("Double") {
     final def apply(c: HCursor): Result[Double] = c.focus match {
-      case JNull => Xor.right(Double.NaN)
-      case JNumber(number) => Xor.right(number.toDouble)
+      case JNull => Right(Double.NaN)
+      case JNumber(number) => Right(number.toDouble)
       case JString(string) => JsonNumber.fromString(string).map(_.toDouble) match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case _ => fail(c)
@@ -419,11 +452,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeByte: Decoder[Byte] = new DecoderWithFailure[Byte]("Byte") {
     final def apply(c: HCursor): Result[Byte] = c.focus match {
       case JNumber(number) => number.toByte match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(string.toByte)
+        Right(string.toByte)
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -441,11 +474,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeShort: Decoder[Short] = new DecoderWithFailure[Short]("Short") {
     final def apply(c: HCursor): Result[Short] = c.focus match {
       case JNumber(number) => number.toShort match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(string.toShort)
+        Right(string.toShort)
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -463,11 +496,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeInt: Decoder[Int] = new DecoderWithFailure[Int]("Int") {
     final def apply(c: HCursor): Result[Int] = c.focus match {
       case JNumber(number) => number.toInt match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(string.toInt)
+        Right(string.toInt)
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -488,11 +521,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeLong: Decoder[Long] = new DecoderWithFailure[Long]("Long") {
     final def apply(c: HCursor): Result[Long] = c.focus match {
       case JNumber(number) => number.toLong match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(string.toLong)
+        Right(string.toLong)
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -513,11 +546,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeBigInt: Decoder[BigInt] = new DecoderWithFailure[BigInt]("BigInt") {
     final def apply(c: HCursor): Result[BigInt] = c.focus match {
       case JNumber(number) => number.toBigInt match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(BigInt(string))
+        Right(BigInt(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -541,11 +574,11 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   implicit final val decodeBigDecimal: Decoder[BigDecimal] = new DecoderWithFailure[BigDecimal]("BigDecimal") {
     final def apply(c: HCursor): Result[BigDecimal] = c.focus match {
       case JNumber(number) => number.toBigDecimal match {
-        case Some(v) => Xor.right(v)
+        case Some(v) => Right(v)
         case None => fail(c)
       }
       case JString(string) => try {
-        Xor.right(BigDecimal(string))
+        Right(BigDecimal(string))
       } catch {
         case _: NumberFormatException => fail(c)
       }
@@ -557,13 +590,13 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Decoding
    */
   implicit final val decodeUUID: Decoder[UUID] = new Decoder[UUID] {
+    private[this] def fail(c: HCursor): Result[UUID] = Left(DecodingFailure("UUID", c.history))
+
     final def apply(c: HCursor): Result[UUID] = c.focus match {
-      case JString(string) if string.length == 36 => try {
-        Xor.right(UUID.fromString(string))
-      } catch {
-        case _: IllegalArgumentException => Xor.left(DecodingFailure("UUID", c.history))
+      case JString(string) if string.length == 36 => try Right(UUID.fromString(string)) catch {
+        case _: IllegalArgumentException => fail(c)
       }
-      case _ => Xor.left(DecodingFailure("UUID", c.history))
+      case _ => fail(c)
     }
   }
 
@@ -575,7 +608,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     cbf: CanBuildFrom[Nothing, A, C[A]]
   ): Decoder[C[A]] = new SeqDecoder[A, C](d, cbf)
 
-  private[this] final val rightNone: Xor[DecodingFailure, Option[Nothing]] = Xor.right(None)
+  private[this] final val rightNone: Either[DecodingFailure, Option[Nothing]] = Right(None)
 
   /**
    * @group Decoding
@@ -584,12 +617,12 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     withReattempt(c =>
       if (c.succeeded) {
         if (c.any.focus.isNull) rightNone else d(c.any) match {
-          case Xor.Right(a) => Xor.right(Some(a))
-          case Xor.Left(df) if df.history.isEmpty => rightNone
-          case Xor.Left(df) => Xor.left(df)
+          case Right(a) => Right(Some(a))
+          case Left(df) if df.history.isEmpty => rightNone
+          case Left(df) => Left(df)
         }
       } else if (!c.history.takeWhile(_.failed).exists(_.incorrectFocus)) rightNone else {
-        Xor.left(DecodingFailure("[A]Option[A]", c.history))
+        Left(DecodingFailure("[A]Option[A]", c.history))
       }
     )
 
@@ -602,8 +635,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
    * @group Decoding
    */
   implicit final val decodeNone: Decoder[None.type] = new Decoder[None.type] {
-    final def apply(c: HCursor): Result[None.type] = if (c.focus.isNull) Xor.right(None) else {
-      Xor.left(DecodingFailure("None", c.history))
+    final def apply(c: HCursor): Result[None.type] = if (c.focus.isNull) Right(None) else {
+      Left(DecodingFailure("None", c.history))
     }
   }
 
@@ -649,6 +682,60 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
     }
 
   /**
+   * @group Decoding
+   */
+  implicit final def decodeNonEmptyList[A](implicit da: Decoder[A]): Decoder[NonEmptyList[A]] =
+    new Decoder[NonEmptyList[A]] {
+      def apply(c: HCursor): Result[NonEmptyList[A]] = {
+        val arr = c.downArray
+
+        da.tryDecode(arr) match {
+          case Right(head) => decodeCanBuildFrom[A, List].tryDecode(arr.delete) match {
+            case Right(tail) => Right(NonEmptyList(head, tail))
+            case l @ Left(_) => l.asInstanceOf[Result[NonEmptyList[A]]]
+          }
+          case l @ Left(_) => l.asInstanceOf[Result[NonEmptyList[A]]]
+        }
+      }
+
+      override private[circe] def decodeAccumulating(
+        c: HCursor
+      ): AccumulatingDecoder.Result[NonEmptyList[A]] = {
+        val arr = c.downArray
+        val head = da.tryDecodeAccumulating(arr)
+        val tail = decodeCanBuildFrom[A, List].tryDecodeAccumulating(arr.delete)
+        tail.ap(head.map(h => (t: List[A]) => NonEmptyList(h, t)))
+      }
+    }
+
+  /**
+   * @group Decoding
+   */
+  implicit final def decodeNonEmptyVector[A](implicit da: Decoder[A]): Decoder[NonEmptyVector[A]] =
+    new Decoder[NonEmptyVector[A]] {
+      def apply(c: HCursor): Result[NonEmptyVector[A]] = {
+        val arr = c.downArray
+
+        da.tryDecode(arr) match {
+          case Right(head) => decodeCanBuildFrom[A, Vector].tryDecode(arr.delete) match {
+            case Right(tail) => Right(NonEmptyVector(head, tail))
+            case l @ Left(_) => l.asInstanceOf[Result[NonEmptyVector[A]]]
+          }
+          case l @ Left(_) => l.asInstanceOf[Result[NonEmptyVector[A]]]
+        }
+      }
+
+      override private[circe] def decodeAccumulating(
+        c: HCursor
+      ): AccumulatingDecoder.Result[NonEmptyVector[A]] = {
+        val arr = c.downArray
+        val head = da.tryDecodeAccumulating(arr)
+        val tail = decodeCanBuildFrom[A, Vector].tryDecodeAccumulating(arr.delete)
+        tail.ap(head.map(h => (t: Vector[A]) => NonEmptyVector(h, t)))
+      }
+    }
+
+  /**
    * @group Disjunction
    */
   final def decodeXor[A, B](leftKey: String, rightKey: String)(implicit
@@ -660,10 +747,16 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       val r = c.downField(rightKey)
 
       if (l.succeeded && !r.succeeded) {
-        da(l.any).map(Xor.left(_))
+        da(l.any) match {
+          case Right(v) => Right(Xor.Left(v))
+          case l @ Left(_) => l.asInstanceOf[Result[Xor[A, B]]]
+        }
       } else if (!l.succeeded && r.succeeded) {
-        db(r.any).map(Xor.right(_))
-      } else Xor.left(DecodingFailure("[A, B]Xor[A, B]", c.history))
+        db(r.any) match {
+          case Right(v) => Right(Xor.Right(v))
+          case l @ Left(_) => l.asInstanceOf[Result[Xor[A, B]]]
+        }
+      } else Left(DecodingFailure("[A, B]Xor[A, B]", c.history))
     }
   }
 
@@ -705,9 +798,9 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
       final def tailRecM[A, B](a: A)(f: A => Decoder[Either[A, B]]): Decoder[B] = new Decoder[B] {
         @tailrec
         private[this] def step(c: HCursor, a1: A): Result[B] = f(a1)(c) match {
-          case l @ Xor.Left(df) => l
-          case Xor.Right(Left(a2)) => step(c, a2)
-          case Xor.Right(Right(b)) => Xor.right(b)
+          case l @ Left(df) => l
+          case Right(Left(a2)) => step(c, a2)
+          case Right(Right(b)) => Right(b)
         }
 
         final def apply(c: HCursor): Result[B] = step(c, a)

--- a/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
+++ b/modules/core/shared/src/main/scala/io/circe/GenericCursor.scala
@@ -1,7 +1,6 @@
 package io.circe
 
 import cats.Functor
-import cats.data.Xor
 
 /**
  * A zipper that represents a position in a JSON document and supports navigation and modification.
@@ -336,9 +335,9 @@ abstract class GenericCursor[C <: GenericCursor[C]] extends Serializable {
    */
   def getOrElse[A](k: String)(fallback: => A)(implicit d: Decoder[A]): Decoder.Result[A] =
     get[Option[A]](k) match {
-      case Xor.Right(Some(a)) => Xor.Right(a)
-      case Xor.Right(None) => Xor.Right(fallback)
-      case l @ Xor.Left(_) => l
+      case Right(Some(a)) => Right(a)
+      case Right(None) => Right(fallback)
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
     }
 
   /**

--- a/modules/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/NonEmptySeqDecoder.scala
@@ -12,10 +12,13 @@ private[circe] abstract class NonEmptySeqDecoder[A, C[_], S](implicit
   final def apply(c: HCursor): Decoder.Result[S] = {
     val arr = c.downArray
 
-    decodeA.tryDecode(arr).flatMap { head =>
-      decodeCA.tryDecode(arr.delete).map { tail =>
-        create(head, tail)
-      }
+    decodeA.tryDecode(arr) match {
+      case Right(head) =>
+        decodeCA.tryDecode(arr.delete) match {
+          case Right(tail) => Right(create(head, tail))
+          case l @ Left(_) => l.asInstanceOf[Decoder.Result[S]]
+        }
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[S]]
     }
   }
 

--- a/modules/core/shared/src/main/scala/io/circe/Parser.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Parser.scala
@@ -1,18 +1,21 @@
 package io.circe
 
-import cats.data.{ NonEmptyList, Validated, ValidatedNel, Xor }
+import cats.data.{ NonEmptyList, Validated, ValidatedNel }
 
 trait Parser extends Serializable {
-  def parse(input: String): Xor[ParsingFailure, Json]
+  def parse(input: String): Either[ParsingFailure, Json]
 
-  final def decode[A](input: String)(implicit decoder: Decoder[A]): Xor[Error, A] =
-    parse(input).flatMap(decoder.decodeJson)
+  final def decode[A](input: String)(implicit decoder: Decoder[A]): Either[Error, A] =
+    parse(input) match {
+      case Right(json) => decoder.decodeJson(json)
+      case l @ Left(_) => l.asInstanceOf[Either[Error, A]]
+    }
 
   final def decodeAccumulating[A](input: String)(implicit decoder: Decoder[A]): ValidatedNel[Error, A] =
     parse(input) match {
-      case Xor.Right(json) => decoder.accumulating(json.hcursor).leftMap {
+      case Right(json) => decoder.accumulating(json.hcursor).leftMap {
         case NonEmptyList(h, t) => NonEmptyList(h, t)
       }
-      case Xor.Left(error) => Validated.invalidNel(error)
+      case Left(error) => Validated.invalidNel(error)
     }
 }

--- a/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/SeqDecoder.scala
@@ -1,6 +1,6 @@
 package io.circe
 
-import cats.data.{ NonEmptyList, Validated, Xor }
+import cats.data.{ NonEmptyList, Validated }
 import scala.collection.generic.CanBuildFrom
 
 private[circe] final class SeqDecoder[A, C[_]](
@@ -16,17 +16,17 @@ private[circe] final class SeqDecoder[A, C[_]](
 
       while (failed.eq(null) && current.succeeded) {
         decodeA(current.any) match {
-          case Xor.Left(e) => failed = e
-          case Xor.Right(a) =>
+          case Left(e) => failed = e
+          case Right(a) =>
             builder += a
             current = current.right
         }
       }
 
-      if (failed.eq(null)) Xor.right(builder.result) else Xor.left(failed)
+      if (failed.eq(null)) Right(builder.result) else Left(failed)
     } else {
-      if (c.focus.isArray) Xor.right(cbf.apply.result) else {
-        Xor.left(DecodingFailure("CanBuildFrom for A", c.history))
+      if (c.focus.isArray) Right(cbf.apply.result) else {
+        Left(DecodingFailure("CanBuildFrom for A", c.history))
       }
     }
   }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/DerivationMacros.scala
@@ -186,7 +186,7 @@ class DerivationMacros(val c: whitebox.Context) {
                 }
               } else {
                 $acc match {
-                  case _root_.scala.util.Right(last) => Right(_root_.shapeless.Inr(last): $current)
+                  case _root_.scala.util.Right(last) => _root_.scala.util.Right(_root_.shapeless.Inr(last): $current)
                   case l @ _root_.scala.util.Left(_) => l.asInstanceOf[_root_.io.circe.Decoder.Result[$current]]
                 }
               }

--- a/modules/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/decoding/DerivedDecoder.scala
@@ -15,7 +15,10 @@ final object DerivedDecoder extends IncompleteDerivedDecoders {
     gen: LabelledGeneric.Aux[A, R],
     decode: Lazy[DerivedDecoder[R]]
   ): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
+    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c) match {
+      case Right(r) => Right(gen.from(r))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
+    }
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       decode.value.decodeAccumulating(c).map(gen.from)
   }
@@ -24,7 +27,10 @@ final object DerivedDecoder extends IncompleteDerivedDecoders {
     gen: LabelledGeneric.Aux[A, R],
     decode: Lazy[DerivedDecoder[R]]
   ): DerivedDecoder[A] = new DerivedDecoder[A] {
-    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c).map(gen.from)
+    final def apply(c: HCursor): Decoder.Result[A] = decode.value(c) match {
+      case Right(r) => Right(gen.from(r))
+      case l @ Left(_) => l.asInstanceOf[Decoder.Result[A]]
+    }
     override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[A] =
       decode.value.decodeAccumulating(c).map(gen.from)
   }

--- a/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
@@ -1,26 +1,25 @@
 package io.circe.jackson
 
-import cats.data.Xor
 import io.circe.{ Json, Parser, ParsingFailure }
 import java.io.File
 import scala.util.control.NonFatal
 
 trait JacksonParser extends Parser { this: WithJacksonMapper =>
-  final def parse(input: String): Xor[ParsingFailure, Json] = try {
-    Xor.right(mapper.readValue(jsonStringParser(input), classOf[Json]))
+  final def parse(input: String): Either[ParsingFailure, Json] = try {
+    Right(mapper.readValue(jsonStringParser(input), classOf[Json]))
   } catch {
-    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+    case NonFatal(error) => Left(ParsingFailure(error.getMessage, error))
   }
 
-  final def parseFile(file: File): Xor[ParsingFailure, Json] = try {
-    Xor.right(mapper.readValue(jsonFileParser(file), classOf[Json]))
+  final def parseFile(file: File): Either[ParsingFailure, Json] = try {
+    Right(mapper.readValue(jsonFileParser(file), classOf[Json]))
   } catch {
-    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+    case NonFatal(error) => Left(ParsingFailure(error.getMessage, error))
   }
 
-  final def parseByteArray(bytes: Array[Byte]): Xor[ParsingFailure, Json] = try {
-    Xor.right(mapper.readValue(jsonBytesParser(bytes), classOf[Json]))
+  final def parseByteArray(bytes: Array[Byte]): Either[ParsingFailure, Json] = try {
+    Right(mapper.readValue(jsonBytesParser(bytes), classOf[Json]))
   } catch {
-    case NonFatal(error) => Xor.left(ParsingFailure(error.getMessage, error))
+    case NonFatal(error) => Left(ParsingFailure(error.getMessage, error))
   }
 }

--- a/modules/java8/src/main/scala/io/circe/java8/time/package.scala
+++ b/modules/java8/src/main/scala/io/circe/java8/time/package.scala
@@ -1,6 +1,5 @@
 package io.circe.java8
 
-import cats.data.Xor
 import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
 import java.time.{ Instant, LocalDate, LocalDateTime, OffsetDateTime, ZonedDateTime }
 import java.time.format.{ DateTimeFormatter, DateTimeParseException }
@@ -14,10 +13,11 @@ import java.time.format.DateTimeFormatter.{
 package object time {
   implicit final val decodeInstant: Decoder[Instant] =
     Decoder.instance { c =>
-      c.as[String].flatMap { s =>
-        try Xor.right(Instant.parse(s)) catch {
-          case _: DateTimeParseException => Xor.left(DecodingFailure("Instant", c.history))
+      c.as[String] match {
+        case Right(s) => try Right(Instant.parse(s)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("Instant", c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[Instant]]
       }
     }
 
@@ -25,10 +25,11 @@ package object time {
 
   final def decodeLocalDateTime(formatter: DateTimeFormatter): Decoder[LocalDateTime] =
     Decoder.instance { c =>
-      c.as[String].flatMap { s =>
-        try Xor.right(LocalDateTime.parse(s, formatter)) catch {
-          case _: DateTimeParseException => Xor.left(DecodingFailure("LocalDateTime", c.history))
+      c.as[String] match {
+        case Right(s) => try Right(LocalDateTime.parse(s, formatter)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("LocalDateTime", c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[LocalDateTime]]
       }
     }
 
@@ -40,10 +41,11 @@ package object time {
 
   final def decodeZonedDateTime(formatter: DateTimeFormatter): Decoder[ZonedDateTime] =
     Decoder.instance { c =>
-      c.as[String].flatMap { s =>
-        try Xor.right(ZonedDateTime.parse(s, formatter)) catch {
-          case _: DateTimeParseException => Xor.left(DecodingFailure("ZonedDateTime", c.history))
+      c.as[String] match {
+        case Right(s) => try Right(ZonedDateTime.parse(s, formatter)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("ZonedDateTime", c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[ZonedDateTime]]
       }
     }
 
@@ -55,10 +57,11 @@ package object time {
 
   final def decodeOffsetDateTime(formatter: DateTimeFormatter): Decoder[OffsetDateTime] =
     Decoder.instance { c =>
-      c.as[String].flatMap { s =>
-        try Xor.right(OffsetDateTime.parse(s, formatter)) catch {
-          case _: DateTimeParseException => Xor.left(DecodingFailure("OffsetDateTime", c.history))
+      c.as[String] match {
+        case Right(s) => try Right(OffsetDateTime.parse(s, formatter)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("OffsetDateTime", c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[OffsetDateTime]]
       }
     }
 
@@ -70,10 +73,11 @@ package object time {
 
   final def decodeLocalDate(formatter: DateTimeFormatter): Decoder[LocalDate] =
     Decoder.instance { c =>
-      c.as[String].flatMap { s =>
-        try Xor.right(LocalDate.parse(s, formatter)) catch {
-          case _: DateTimeParseException => Xor.left(DecodingFailure("LocalDate", c.history))
+      c.as[String] match {
+        case Right(s) => try Right(LocalDate.parse(s, formatter)) catch {
+          case _: DateTimeParseException => Left(DecodingFailure("LocalDate", c.history))
         }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[LocalDate]]
       }
     }
 

--- a/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
@@ -1,21 +1,22 @@
 package io.circe.jawn
 
-import cats.data.Xor
 import io.circe.{ Json, Parser, ParsingFailure }
 import java.io.File
 import java.nio.ByteBuffer
-import scala.util.Try
+import scala.util.{ Failure, Success, Try }
 
 class JawnParser extends Parser {
-  private[this] final def fromTry(t: Try[Json]): Xor[ParsingFailure, Json] =
-    Xor.fromTry(t).leftMap(error => ParsingFailure(error.getMessage, error))
+  private[this] final def fromTry(t: Try[Json]): Either[ParsingFailure, Json] = t match {
+    case Success(json) => Right(json)
+    case Failure(error) => Left(ParsingFailure(error.getMessage, error))
+  }
 
-  final def parse(input: String): Xor[ParsingFailure, Json] =
+  final def parse(input: String): Either[ParsingFailure, Json] =
     fromTry(CirceSupportParser.parseFromString(input))
 
-  final def parseFile(file: File): Xor[ParsingFailure, Json] =
+  final def parseFile(file: File): Either[ParsingFailure, Json] =
     fromTry(CirceSupportParser.parseFromFile(file))
 
-  final def parseByteBuffer(buffer: ByteBuffer): Xor[ParsingFailure, Json] =
+  final def parseByteBuffer(buffer: ByteBuffer): Either[ParsingFailure, Json] =
     fromTry(CirceSupportParser.parseFromByteBuffer(buffer))
 }

--- a/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
+++ b/modules/literal/src/main/scala/io/circe/literal/LiteralMacros.scala
@@ -1,11 +1,11 @@
 package io.circe.literal
 
-import cats.data.Xor
 import io.circe.Json
 import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 import java.util.UUID
 import macrocompat.bundle
 import scala.reflect.macros.whitebox
+import scala.util.control.NonFatal
 
 @bundle
 class LiteralMacros(val c: whitebox.Context) {
@@ -127,8 +127,8 @@ class LiteralMacros(val c: whitebox.Context) {
   final def parse(
     jsonString: String,
     placeHolders: Map[String, (Tree, Option[Tree])]
-  ): Xor[Throwable, Tree] =
-    Xor.catchNonFatal {
+  ): Either[Throwable, Tree] =
+    try Right {
       val jawnParserClass = Class.forName("jawn.Parser$")
       val jawnParser = jawnParserClass.getField("MODULE$").get(jawnParserClass)
       val jawnFacadeClass = Class.forName("jawn.Facade")
@@ -139,6 +139,8 @@ class LiteralMacros(val c: whitebox.Context) {
         jsonString,
         new TreeFacadeHandler(placeHolders).asProxy(jawnFacadeClass)
       ).asInstanceOf[Tree]
+    } catch {
+      case NonFatal(e) => Left(e)
     }
 
   private[this] final def randomPlaceHolder(): String = UUID.randomUUID().toString
@@ -185,12 +187,13 @@ class LiteralMacros(val c: whitebox.Context) {
         } + stringParts.last
 
         c.Expr[Json](
-          parse(jsonString, encodedArgs.toMap).valueOr[Tree] {
-            case _: ClassNotFoundException => c.abort(
+          parse(jsonString, encodedArgs.toMap) match {
+            case Right(tree) => tree
+            case Left(_: ClassNotFoundException) => c.abort(
               c.enclosingPosition,
               "The json interpolator requires jawn to be available at compile time"
             )
-            case t: Throwable => c.abort(
+            case Left(t: Throwable) => c.abort(
               c.enclosingPosition,
               "Invalid JSON in interpolated string"
             )
@@ -207,13 +210,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asString.flatMap[$sType] {
-                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asString.exists(_ == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -225,13 +228,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asBoolean.flatMap[$sType] {
-                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asBoolean.exists(_ == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -243,13 +246,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asNumber.map(_.toDouble).flatMap[$sType] {
-                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asNumber.map(_.toDouble).exists(_ == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -261,13 +264,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asNumber.map(_.toDouble).flatMap[$sType] {
-                case s if s.toFloat == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asNumber.map(_.toDouble).exists(s => s.toFloat == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -279,13 +282,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asNumber.flatMap(_.toLong).flatMap[$sType] {
-                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asNumber.flatMap(_.toLong).exists(_ == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -297,13 +300,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asNumber.flatMap(_.toInt).flatMap[$sType] {
-                case s if s == $lit => _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asNumber.flatMap(_.toInt).exists(_ == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }
@@ -315,14 +318,13 @@ class LiteralMacros(val c: whitebox.Context) {
 
         q"""
           _root_.io.circe.Decoder.instance[$sType] { c =>
-            _root_.cats.data.Xor.fromOption(
-              c.focus.asString.flatMap[$sType] {
-                case s if s.length == 1 && s.charAt(0) == $lit =>
-                  _root_.scala.Some[$sType]($lit: $sType)
-                case _ => _root_.scala.None
-              },
-              _root_.io.circe.DecodingFailure($name, c.history)
-            )
+            if (c.focus.asString.exists(s => s.length == 1 && s.charAt(0) == $lit)) {
+              _root_.scala.util.Right[_root_.io.circe.DecodingFailure, $sType]($lit: $sType)
+            } else {
+              _root_.scala.util.Left(
+                _root_.io.circe.DecodingFailure($name, c.history)
+              )
+            }
           }
         """
     }

--- a/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
+++ b/modules/optics/src/main/scala/io/circe/optics/JsonPath.scala
@@ -49,7 +49,12 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
    */
   final def as[A](implicit decode: Decoder[A], encode: Encoder[A]): Optional[Json, A] =
     json.composePrism(
-      Prism((j: Json) => decode.decodeJson(j).toOption)(encode(_))
+      Prism((j: Json) =>
+        decode.decodeJson(j) match {
+          case Right(a) => Some(a)
+          case Left(_) => None
+        }
+      )(encode(_))
     )
 }
 
@@ -92,6 +97,11 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
 
   final def as[A](implicit decode: Decoder[A], encode: Encoder[A]): Traversal[Json, A] =
     json.composePrism(
-      Prism((j: Json) => decode.decodeJson(j).toOption)(encode(_))
+      Prism((j: Json) =>
+        decode.decodeJson(j) match {
+          case Right(a) => Some(a)
+          case Left(_) => None
+        }
+      )(encode(_))
     )
 }

--- a/modules/parser/js/src/main/scala/io/circe/parser/package.scala
+++ b/modules/parser/js/src/main/scala/io/circe/parser/package.scala
@@ -1,12 +1,16 @@
 package io.circe
 
-import cats.data.Xor
 import io.circe.scalajs.convertJsToJson
 import scala.scalajs.js.JSON
+import scala.util.control.NonFatal
 
 package object parser extends Parser {
-  def parse(input: String): Xor[ParsingFailure, Json] =
-    Xor.catchNonFatal(JSON.parse(input)).flatMap(convertJsToJson).leftMap(exception =>
-      ParsingFailure(exception.getMessage, exception)
-    )
+  final def parse(input: String): Either[ParsingFailure, Json] = (
+    try convertJsToJson(JSON.parse(input)) catch {
+      case NonFatal(exception) => Left(ParsingFailure(exception.getMessage, exception))
+    }
+  ) match {
+    case r @ Right(_) => r.asInstanceOf[Either[ParsingFailure, Json]]
+    case Left(exception) => Left(ParsingFailure(exception.getMessage, exception))
+  }
 }

--- a/modules/parser/jvm/src/main/scala/io/circe/parser/package.scala
+++ b/modules/parser/jvm/src/main/scala/io/circe/parser/package.scala
@@ -1,10 +1,9 @@
 package io.circe
 
-import cats.data.Xor
 import io.circe.jawn.JawnParser
 
 package object parser extends Parser {
   private[this] val parser = new JawnParser
 
-  def parse(input: String): Xor[ParsingFailure, Json] = parser.parse(input)
+  def parse(input: String): Either[ParsingFailure, Json] = parser.parse(input)
 }

--- a/modules/scodec/shared/src/main/scala/io/circe/scodec.scala
+++ b/modules/scodec/shared/src/main/scala/io/circe/scodec.scala
@@ -1,16 +1,17 @@
 package io.circe
 
 import _root_.scodec.bits.{BitVector, ByteVector}
-import cats.data.Xor
 
 package object scodec {
   implicit final val decodeBitVector: Decoder[BitVector] =
     Decoder.instance { c =>
-      Decoder.decodeString(c).flatMap { str =>
-        BitVector.fromBase64Descriptive(str) match {
-          case Right(bits) => Xor.right(bits)
-          case Left(err) => Xor.left(DecodingFailure(err, c.history))
-        }
+      Decoder.decodeString(c) match {
+        case Right(str) =>
+          BitVector.fromBase64Descriptive(str) match {
+            case r @ Right(_) => r.asInstanceOf[Decoder.Result[BitVector]]
+            case Left(err) => Left(DecodingFailure(err, c.history))
+          }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[BitVector]]
       }
     }
 
@@ -19,11 +20,13 @@ package object scodec {
 
   implicit final val decodeByteVector: Decoder[ByteVector] =
     Decoder.instance { c =>
-      Decoder.decodeString(c).flatMap { str =>
-        ByteVector.fromBase64Descriptive(str) match {
-          case Right(bytes) => Xor.right(bytes)
-          case Left(err) => Xor.left(DecodingFailure(err, c.history))
-        }
+      Decoder.decodeString(c) match {
+        case Right(str) =>
+          ByteVector.fromBase64Descriptive(str) match {
+            case r @ Right(_) => r.asInstanceOf[Decoder.Result[ByteVector]]
+            case Left(err) => Left(DecodingFailure(err, c.history))
+          }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[ByteVector]]
       }
     }
 

--- a/modules/spray/src/main/scala/io/circe/spray/JsonSupport.scala
+++ b/modules/spray/src/main/scala/io/circe/spray/JsonSupport.scala
@@ -22,7 +22,10 @@ trait FailFastUnmarshaller { this: JsonSupport =>
   implicit final def circeJsonUnmarshaller[A](implicit decoder: RootDecoder[A]): Unmarshaller[A] =
     Unmarshaller[A](MediaTypes.`application/json`) {
       case x: HttpEntity.NonEmpty =>
-        decode[A](x.asString(defaultCharset = HttpCharsets.`UTF-8`))(decoder.underlying).valueOr(throw _)
+        decode[A](x.asString(defaultCharset = HttpCharsets.`UTF-8`))(decoder.underlying) match {
+          case Right(a) => a
+          case Left(e) => throw e
+        }
     }
 }
 

--- a/modules/streaming/src/main/scala/io/circe/streaming/package.scala
+++ b/modules/streaming/src/main/scala/io/circe/streaming/package.scala
@@ -2,7 +2,6 @@ package io.circe
 
 import _root_.jawn.{ AsyncParser, ParseException }
 import cats.{ ApplicativeError, MonadError }
-import cats.data.Xor
 import io.circe.jawn.CirceSupportParser
 import io.iteratee.{ Enumeratee, Enumerator }
 
@@ -22,8 +21,8 @@ package object streaming {
   final def decoder[F[_], A](implicit F: MonadError[F, Throwable], decode: Decoder[A]): Enumeratee[F, Json, A] =
     Enumeratee.flatMap(json =>
       decode(json.hcursor) match {
-        case Xor.Left(df) => Enumerator.liftM(F.raiseError(df))
-        case Xor.Right(a) => Enumerator.enumOne(a)
+        case Left(df) => Enumerator.liftM(F.raiseError(df))
+        case Right(a) => Enumerator.enumOne(a)
       }
     )
 }

--- a/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
+++ b/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
@@ -1,6 +1,5 @@
 package io.circe.scalajs
 
-import cats.data.Xor
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto._
 import io.circe.tests.CirceSuite
@@ -23,17 +22,17 @@ object UndefOrExample {
 
 class ScalaJsSuite extends CirceSuite {
   "decodeJs" should "decode js.Object" in forAll { (s: String) =>
-    assert(decodeJs[Example](Dynamic.literal(name = s)).map(_.name) === Xor.right(s))
+    assert(decodeJs[Example](Dynamic.literal(name = s)).map(_.name) === Right(s))
   }
 
   it should "handle undefined js.UndefOr when decoding js.Object" in {
     val res = decodeJs[UndefOrExample](Dynamic.literal(name = js.undefined))
 
-    assert(res.map(_.name.isDefined) === Xor.right(false))
+    assert(res.map(_.name.isDefined) === Right(false))
   }
 
   it should "handle defined js.UndefOr when decoding js.Object" in forAll { (s: String) =>
-    assert(decodeJs[UndefOrExample](Dynamic.literal(name = s)).map(_.name.get) === Xor.right(s))
+    assert(decodeJs[UndefOrExample](Dynamic.literal(name = s)).map(_.name.get) === Right(s))
   }
 
   "asJsAny" should "encode to js.Object" in forAll { (s: String) =>

--- a/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/LargeNumberDecoderTests.scala
@@ -1,6 +1,5 @@
 package io.circe
 
-import cats.data.Xor
 import io.circe.parser.parse
 import io.circe.tests.CirceSuite
 
@@ -10,15 +9,15 @@ import io.circe.tests.CirceSuite
 trait LargeNumberDecoderTests { this: CirceSuite =>
   "Decoder[Long]" should "succeed on whole decimal values (#83)" in forAll { (v: Long, n: Byte) =>
     val zeros = "0" * (math.abs(n.toInt) + 1)
-    val Xor.Right(json) = parse(s"$v.$zeros")
+    val Right(json) = parse(s"$v.$zeros")
 
-    assert(Decoder[Long].apply(json.hcursor) === Xor.right(v))
+    assert(Decoder[Long].apply(json.hcursor) === Right(v))
   }
 
   "Decoder[BigInt]" should "succeed on whole decimal values (#83)" in forAll { (v: BigInt, n: Byte) =>
     val zeros = "0" * (math.abs(n.toInt) + 1)
-    val Xor.Right(json) = parse(s"$v.$zeros")
+    val Right(json) = parse(s"$v.$zeros")
 
-    assert(Decoder[BigInt].apply(json.hcursor) === Xor.right(v))
+    assert(Decoder[BigInt].apply(json.hcursor) === Right(v))
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
@@ -1,6 +1,5 @@
 package io.circe.jackson
 
-import cats.data.Xor
 import io.circe.tests.{ CirceSuite, ParserTests }
 import io.circe.tests.examples.glossary
 import java.io.File
@@ -17,7 +16,7 @@ class JacksonParserSuite extends CirceSuite {
     val url = getClass.getResource("/io/circe/tests/examples/glossary.json")
     val file = new File(url.toURI)
 
-    assert(parseFile(file) === Xor.right(glossary))
+    assert(parseFile(file) === Right(glossary))
   }
 
   "parseByteArray" should "parse an array of bytes" in {
@@ -26,6 +25,6 @@ class JacksonParserSuite extends CirceSuite {
     val bytes = source.map(_.toByte).toArray
     source.close()
 
-    assert(parseByteArray(bytes) === Xor.right(glossary))
+    assert(parseByteArray(bytes) === Right(glossary))
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
@@ -1,11 +1,10 @@
 package io.circe.jackson
 
-import cats.data.Xor
 import io.circe.Json
 import io.circe.tests.CirceSuite
 
 class JacksonPrintingSuite extends CirceSuite {
   "jacksonPrint" should "produce round-trippable output" in forAll { (json: Json) =>
-    assert(io.circe.jawn.parse(jacksonPrint(json)) === Xor.right(json))
+    assert(io.circe.jawn.parse(jacksonPrint(json)) === Right(json))
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
@@ -1,6 +1,5 @@
 package io.circe.jawn
 
-import cats.data.Xor
 import io.circe.tests.{ CirceSuite, ParserTests }
 import io.circe.tests.examples.glossary
 import java.io.File
@@ -18,7 +17,7 @@ class JawnParserSuite extends CirceSuite {
     val url = getClass.getResource("/io/circe/tests/examples/glossary.json")
     val file = new File(url.toURI)
 
-    assert(parseFile(file) === Xor.right(glossary))
+    assert(parseFile(file) === Right(glossary))
   }
 
   "parseByteBuffer" should "parse a byte buffer" in {
@@ -29,6 +28,6 @@ class JawnParserSuite extends CirceSuite {
 
     val buffer = ByteBuffer.wrap(bytes)
 
-    assert(parseByteBuffer(buffer) === Xor.right(glossary))
+    assert(parseByteBuffer(buffer) === Right(glossary))
   }
 }

--- a/modules/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/ArbitraryInstances.scala
@@ -1,6 +1,6 @@
 package io.circe.tests
 
-import cats.data.{ ValidatedNel, Xor }
+import cats.data.ValidatedNel
 import io.circe._
 import io.circe.Json.{ JArray, JNumber, JObject, JString }
 import java.util.UUID
@@ -113,7 +113,7 @@ trait ArbitraryInstances {
   )
 
   implicit def arbitraryDecoder[A](implicit
-    arbitraryF: Arbitrary[Json => Xor[DecodingFailure, A]]
+    arbitraryF: Arbitrary[Json => Either[DecodingFailure, A]]
   ): Arbitrary[Decoder[A]] = Arbitrary(
     arbitraryF.arbitrary.map(f =>
       Decoder.instance(c => f(c.focus))

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -16,6 +16,9 @@ trait CirceSuite extends FlatSpec with GeneratorDrivenPropertyChecks
   override def convertToEqualizer[T](left: T): Equalizer[T] =
     sys.error("Intentionally ambiguous implicit for Equalizer")
 
+  override def catsSyntaxEither[A, B](eab: Either[A, B]): cats.syntax.EitherOps[A, B] =
+    sys.error("Intentionally ambiguous implicit for EitherOps")
+
   def checkLaws(name: String, ruleSet: Laws#RuleSet): Unit = ruleSet.all.properties.zipWithIndex.foreach {
     case ((id, prop), 0) => name should s"obey $id" in Checkers.check(prop)
     case ((id, prop), _) => it should s"obey $id" in Checkers.check(prop)

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CirceSuite.scala
@@ -1,10 +1,11 @@
 package io.circe.tests
 
 import cats.instances.AllInstances
-import cats.syntax.AllSyntax
+import cats.syntax.{ AllSyntax, EitherOps }
 import org.scalatest.FlatSpec
 import org.scalatest.prop.{ Checkers, GeneratorDrivenPropertyChecks }
 import org.typelevel.discipline.Laws
+import scala.language.implicitConversions
 
 /**
  * An opinionated stack of traits to improve consistency and reduce boilerplate in circe tests.
@@ -16,8 +17,7 @@ trait CirceSuite extends FlatSpec with GeneratorDrivenPropertyChecks
   override def convertToEqualizer[T](left: T): Equalizer[T] =
     sys.error("Intentionally ambiguous implicit for Equalizer")
 
-  override def catsSyntaxEither[A, B](eab: Either[A, B]): cats.syntax.EitherOps[A, B] =
-    sys.error("Intentionally ambiguous implicit for EitherOps")
+  implicit def prioritizedCatsSyntaxEither[A, B](eab: Either[A, B]): EitherOps[A, B] = new EitherOps(eab)
 
   def checkLaws(name: String, ruleSet: Laws#RuleSet): Unit = ruleSet.all.properties.zipWithIndex.foreach {
     case ((id, prop), 0) => name should s"obey $id" in Checkers.check(prop)

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CodecTests.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CodecTests.scala
@@ -1,7 +1,7 @@
 package io.circe.tests
 
 import cats.Eq
-import cats.data.Xor
+import cats.instances.either._
 import cats.laws._
 import cats.laws.discipline._
 import io.circe.{ Decoder, Encoder, Json }
@@ -14,10 +14,10 @@ trait CodecLaws[A] {
   def encode: Encoder[A]
 
   def codecRoundTrip(a: A): IsEq[Decoder.Result[A]] =
-    encode(a).as(decode) <-> Xor.right(a)
+    encode(a).as(decode) <-> Right(a)
 
   def codecAccumulatingConsistency(json: Json): IsEq[Decoder.Result[A]] =
-    decode(json.hcursor) <-> decode.accumulating(json.hcursor).leftMap(_.head).toXor
+    decode(json.hcursor) <-> decode.accumulating(json.hcursor).leftMap(_.head).toEither
 }
 
 object CodecLaws {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/CursorSuite.scala
@@ -1,7 +1,6 @@
 package io.circe.tests
 
 import cats.Eq
-import cats.data.Xor
 import io.circe.{ GenericCursor, Json }
 import io.circe.syntax._
 
@@ -226,7 +225,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
     val result = for {
       c <- fromResult(cursor.downField("a"))
       a <- fromResult(c.downN(3))
-      l <- fromResult(a.leftAt(_.as[Int].exists(_ == 1)))
+      l <- fromResult(a.leftAt(_.as[Int].right.exists(_ == 1)))
     } yield l
 
     assert(result.flatMap(focus) === Some(1.asJson))
@@ -235,7 +234,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
   it should "fail to select a value that doesn't exist" in {
     val result = for {
       c <- fromResult(cursor.downField("b"))
-      l <- fromResult(c.leftAt(_.as[Int].exists(_ == 1)))
+      l <- fromResult(c.leftAt(_.as[Int].right.exists(_ == 1)))
     } yield l
 
     assert(result.flatMap(focus) === None)
@@ -245,7 +244,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
     val result = for {
       c <- fromResult(cursor.downField("a"))
       a <- fromResult(c.downN(3))
-      r <- fromResult(a.rightAt(_.as[Int].exists(_ == 5)))
+      r <- fromResult(a.rightAt(_.as[Int].right.exists(_ == 5)))
     } yield r
 
     assert(result.flatMap(focus) === Some(5.asJson))
@@ -254,7 +253,7 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
   it should "fail to select a value that doesn't exist" in {
     val result = for {
       c <- fromResult(cursor.downField("b"))
-      r <- fromResult(c.rightAt(_.as[Int].exists(_ == 5)))
+      r <- fromResult(c.rightAt(_.as[Int].right.exists(_ == 5)))
     } yield r
 
     assert(result.flatMap(focus) === None)
@@ -274,14 +273,14 @@ abstract class CursorSuite[C <: GenericCursor[C]](implicit
     val result = for {
       b <- fromResult(cursor.downField("b"))
     } yield b.getOrElse[List[Boolean]]("d")(Nil)
-    assert(result === Some(Xor.Right(List(true, false, true))))
+    assert(result === Some(Right(List(true, false, true))))
   }
 
   it should "use the fallback if field is missing" in {
     val result = for {
       b <- fromResult(cursor.downField("b"))
     } yield b.getOrElse[List[Boolean]]("z")(Nil)
-    assert(result === Some(Xor.Right(Nil)))
+    assert(result === Some(Right(Nil)))
   }
 
   it should "fail if the field is the wrong type" in {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/EqInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/EqInstances.scala
@@ -1,6 +1,7 @@
 package io.circe.tests
 
 import cats.Eq
+import cats.instances.either._
 import cats.syntax.eq._
 import io.circe.{ AccumulatingDecoder, Decoder, Encoder, Json }
 import org.scalacheck.Arbitrary

--- a/modules/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/ParserTests.scala
@@ -1,6 +1,6 @@
 package io.circe.tests
 
-import cats.data.Xor
+import cats.instances.either._
 import cats.laws._
 import cats.laws.discipline._
 import io.circe.{ Json, Parser, ParsingFailure }
@@ -8,11 +8,11 @@ import org.scalacheck.{ Arbitrary, Prop }
 import org.typelevel.discipline.Laws
 
 case class ParserLaws(parser: Parser) {
-  def parsingRoundTripNoSpaces(json: Json): IsEq[Xor[ParsingFailure, Json]] =
-    parser.parse(json.noSpaces) <-> Xor.right(json)
+  def parsingRoundTripNoSpaces(json: Json): IsEq[Either[ParsingFailure, Json]] =
+    parser.parse(json.noSpaces) <-> Right(json)
 
-  def parsingRoundTripSpaces(json: Json): IsEq[Xor[ParsingFailure, Json]] =
-    parser.parse(json.spaces2) <-> Xor.right(json)
+  def parsingRoundTripSpaces(json: Json): IsEq[Either[ParsingFailure, Json]] =
+    parser.parse(json.spaces2) <-> Right(json)
 }
 
 case class ParserTests(p: Parser) extends Laws {

--- a/modules/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/PrinterTests.scala
@@ -14,7 +14,7 @@ trait PrinterLaws[A] {
   def encode: Encoder[A]
 
   def printerRoundTrip(printer: Printer, parser: Parser, a: A): IsEq[Option[A]] =
-    parser.decode(printer.pretty(encode(a)))(decode).toOption <-> Some(a)
+    parser.decode(printer.pretty(encode(a)))(decode).right.toOption <-> Some(a)
 }
 
 object PrinterLaws {

--- a/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/CodecSuites.scala
@@ -56,7 +56,7 @@ class StdLibCodecSuite extends CirceSuite {
     val json = Encoder[(Int, String, Char)].apply(t)
     val target = Json.arr(Json.fromInt(t._1), Json.fromString(t._2), Encoder[Char].apply(t._3))
 
-    assert(json === target && json.as[(Int, String, Char)] === Xor.right(t))
+    assert(json === target && json.as[(Int, String, Char)] === Right(t))
   }
 
   "A tuple decoder" should "fail if not given enough elements" in forAll { (i: Int, s: String) =>
@@ -74,7 +74,7 @@ class StdLibCodecSuite extends CirceSuite {
     val maybeList = jsonArr.as[List[Int]]
     assert(maybeList.isRight)
 
-    val list = maybeList.getOrElse(???)
+    val list = maybeList.right.getOrElse(???)
     assert(list.length == size)
     assert(list.forall(_ == 1))
   }

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -1,6 +1,5 @@
 package io.circe
 
-import cats.data.Xor
 import cats.laws.discipline.ContravariantTests
 import io.circe.syntax._
 import io.circe.tests.CirceSuite
@@ -13,7 +12,7 @@ class EncoderSuite extends CirceSuite {
       _.withObject(obj => Json.fromJsonObject(obj.add(k, v.asJson)))
     )
 
-    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Xor.right(m.updated(k, v)))
+    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Right(m.updated(k, v)))
   }
 
   "Encoder[Enumeration]" should "write Scala Enumerations" in {
@@ -25,6 +24,6 @@ class EncoderSuite extends CirceSuite {
     implicit val encoder = Encoder.enumEncoder(WeekDay)
     val json = WeekDay.Fri.asJson
     val decoder = Decoder.enumDecoder(WeekDay)
-    assert(decoder.apply(json.hcursor) == Xor.right(WeekDay.Fri))
+    assert(decoder.apply(json.hcursor) == Right(WeekDay.Fri))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/ObjectEncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/ObjectEncoderSuite.scala
@@ -1,6 +1,5 @@
 package io.circe
 
-import cats.data.Xor
 import io.circe.syntax._
 import io.circe.tests.CirceSuite
 
@@ -8,6 +7,6 @@ class ObjectEncoderSuite extends CirceSuite {
   "mapJsonObject" should "transform encoded output" in forAll { (m: Map[String, Int], k: String, v: Int) =>
     val newEncoder = ObjectEncoder[Map[String, Int]].mapJsonObject(_.add(k, v.asJson))
 
-    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Xor.right(m.updated(k, v)))
+    assert(Decoder[Map[String, Int]].apply(newEncoder(m).hcursor) === Right(m.updated(k, v)))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/AutoDerivedSuite.scala
@@ -1,7 +1,6 @@
 package io.circe.generic
 
 import cats.Eq
-import cats.data.Xor
 import io.circe.{ Decoder, Encoder, Json }
 import io.circe.generic.auto._
 import io.circe.tests.{ CodecTests, CirceSuite }
@@ -84,7 +83,7 @@ class AutoDerivedSuite extends CirceSuite {
       "j" -> Json.fromInt(j)
     ).as[Int => Qux[String]].map(_(i))
 
-    assert(result === Xor.right(Qux(i, s, j)))
+    assert(result === Right(Qux(i, s, j)))
   }
 
   "Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]" should "decode partial JSON representations" in {
@@ -96,7 +95,7 @@ class AutoDerivedSuite extends CirceSuite {
          _(field(j))
       )
 
-      assert(result === Xor.right(Qux(i, s, j)))
+      assert(result === Right(Qux(i, s, j)))
     }
   }
 
@@ -110,14 +109,14 @@ class AutoDerivedSuite extends CirceSuite {
 
       val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a), j.getOrElse(q.j))
 
-      assert(json.as[Qux[String] => Qux[String]].map(_(q)) === Xor.right(expected))
+      assert(json.as[Qux[String] => Qux[String]].map(_(q)) === Right(expected))
     }
   }
 
   "A generically derived codec" should "not interfere with base instances" in forAll { (is: List[Int]) =>
     val json = Encoder[List[Int]].apply(is)
 
-    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Xor.right(is))
+    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
   }
 
   it should "not be derived for Object" in {
@@ -133,7 +132,7 @@ class AutoDerivedSuite extends CirceSuite {
   "Generic decoders" should "not interfere with defined decoders" in forAll { (xs: List[String]) =>
     val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
 
-    assert(Decoder[Foo].apply(json.hcursor) === Xor.right(Baz(xs): Foo))
+    assert(Decoder[Foo].apply(json.hcursor) === Right(Baz(xs): Foo))
   }
 
   "Generic encoders" should "not interfere with defined encoders" in forAll { (xs: List[String]) =>

--- a/modules/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -1,7 +1,6 @@
 package io.circe.generic
 
 import cats.Eq
-import cats.data.Xor
 import io.circe.{ Decoder, Encoder, Json, ObjectEncoder }
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
@@ -91,7 +90,7 @@ class SemiautoDerivedSuite extends CirceSuite {
       "j" -> Json.fromInt(j)
     ).as[Int => Qux[String]].map(_(i))
 
-    assert(result === Xor.right(Qux(i, s, j)))
+    assert(result === Right(Qux(i, s, j)))
   }
 
   "Decoder[FieldType[Witness.`'j`.T, Int] => Qux[String]]" should "decode partial JSON representations" in {
@@ -103,7 +102,7 @@ class SemiautoDerivedSuite extends CirceSuite {
          _(field(j))
       )
 
-      assert(result === Xor.right(Qux(i, s, j)))
+      assert(result === Right(Qux(i, s, j)))
     }
   }
 
@@ -117,14 +116,14 @@ class SemiautoDerivedSuite extends CirceSuite {
 
       val expected = Qux[String](i.getOrElse(q.i), a.getOrElse(q.a), j.getOrElse(q.j))
 
-      assert(json.as[Qux[String] => Qux[String]].map(_(q)) === Xor.right(expected))
+      assert(json.as[Qux[String] => Qux[String]].map(_(q)) === Right(expected))
     }
   }
 
   "A generically derived codec" should "not interfere with base instances" in forAll { (is: List[Int]) =>
     val json = Encoder[List[Int]].apply(is)
 
-    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Xor.right(is))
+    assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
   }
 
   it should "not come from nowhere" in {

--- a/modules/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/literal/JsonInterpolatorSuite.scala
@@ -1,6 +1,5 @@
 package io.circe.literal
 
-import cats.data.Xor
 import io.circe.parser.parse
 import io.circe.tests.CirceSuite
 import shapeless.test.illTyped
@@ -29,7 +28,7 @@ class JsonInterpolatorSuite extends CirceSuite {
       """
     )
 
-    assert(parsed === Xor.right(interpolated))
+    assert(parsed === Right(interpolated))
   }
 
   it should "work with interpolated variables" in {
@@ -50,7 +49,7 @@ class JsonInterpolatorSuite extends CirceSuite {
       """
     )
 
-    assert(parsed === Xor.right(interpolated))
+    assert(parsed === Right(interpolated))
   }
 
   it should "work with interpolated strings as keys" in {
@@ -60,7 +59,7 @@ class JsonInterpolatorSuite extends CirceSuite {
 
     val parsed = parse("""{ "foo": 1 }""")
 
-    assert(parsed === Xor.right(interpolated))
+    assert(parsed === Right(interpolated))
   }
 
   it should "fail with invalid JSON" in {

--- a/modules/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/literal/LiteralInstancesSuite.scala
@@ -1,7 +1,6 @@
 package io.circe.literal
 
 import cats.Eq
-import cats.data.Xor
 import io.circe.{ Decoder, Encoder }
 import io.circe.tests.CirceSuite
 import shapeless.Witness
@@ -20,42 +19,42 @@ class LiteralInstancesSuite extends CirceSuite {
   "A literal String codec" should "round-trip values" in {
     val w = Witness("foo")
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Boolean codec" should "round-trip values" in {
     val w = Witness(true)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Float codec" should "round-trip values" in {
     val w = Witness(0.0F)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Double codec" should "round-trip values" in {
     val w = Witness(0.0)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Char codec" should "round-trip values" in {
     val w = Witness('a')
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Int codec" should "round-trip values" in {
     val w = Witness(0)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 
   "A literal Long codec" should "round-trip values" in {
     val w = Witness(0L)
 
-    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Xor.right(w.value))
+    assert(Decoder[w.T].apply(Encoder[w.T].apply(w.value).hcursor) === Right(w.value))
   }
 }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -114,7 +114,7 @@ object Boilerplate {
       }.mkString(", ")
 
       val result =
-        if (arity == 1) s"$applied.map(Tuple1(_))" else s"Decoder.resultInstance.tuple$arity($applied)"
+        if (arity == 1) s"Decoder.resultInstance.map($applied)(Tuple1(_))" else s"Decoder.resultInstance.tuple$arity($applied)"
 
       val accumulatingResult =
         if (arity == 1) s"$accumulatingApplied.map(Tuple1(_))"
@@ -123,7 +123,7 @@ object Boilerplate {
       block"""
         |package io.circe
         |
-        |import cats.data.{ NonEmptyList, Xor }
+        |import cats.data.Validated
         |
         |private[circe] trait TupleDecoders {
         -  /**
@@ -132,18 +132,19 @@ object Boilerplate {
         -  implicit final def decodeTuple$arity[${`A..N`}](implicit $instances): Decoder[${`(A..N)`}] =
         -    new Decoder[${`(A..N)`}] {
         -      final def apply(c: HCursor): Decoder.Result[${`(A..N)`}] = c.as[Vector[HCursor]] match {
-        -        case Xor.Right(js) => if (js.size == $arity) {
+        -        case Right(js) => if (js.size == $arity) {
         -          $result
-        -        } else Xor.left(DecodingFailure("${`(A..N)`}", c.history))
-        -        case l @ Xor.Left(_) => l
+        -        } else Left(DecodingFailure("${`(A..N)`}", c.history))
+        -        case l @ Left(_) => l.asInstanceOf[Decoder.Result[${`(A..N)`}]]
         -      }
         -
         -      override final def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[${`(A..N)`}] =
-        -        c.as[Vector[HCursor]].leftMap[NonEmptyList[DecodingFailure]](NonEmptyList(_, Nil)).flatMap { js =>
-        -          if (js.size == $arity) {
-        -            $accumulatingResult.toXor
-        -          } else Xor.left(NonEmptyList(DecodingFailure("${`(A..N)`}", c.history), Nil))
-        -        }.toValidated
+        -        c.as[Vector[HCursor]] match {
+        -          case Right(js) => if (js.size == $arity) {
+        -            $accumulatingResult
+        -          } else Validated.invalidNel(DecodingFailure("${`(A..N)`}", c.history))
+        -          case Left(e) => Validated.invalidNel(e)
+        -        }
         -    }
         |}
       """
@@ -221,7 +222,7 @@ object Boilerplate {
       ).mkString(",")
 
       val result =
-        if (arity == 1) s"($results).map(f)" else s"Decoder.resultInstance.map$arity($results)(f)"
+        if (arity == 1) s"Decoder.resultInstance.map($results)(f)" else s"Decoder.resultInstance.map$arity($results)(f)"
 
       val accumulatingResult =
         if (arity == 1) s"$accumulatingResults.map(f)"


### PR DESCRIPTION
This is in response to the [proposal in Cats](https://github.com/typelevel/cats/issues/1192) to get rid of `Xor` now that the standard library's `Either` will be slightly less terrible in 2.12.

I'm still opposed to that proposal, but it seems like I'm the only one, so I wanted to put together a quick proof-of-concept of what this would look like in Cats. This PR still needs a lot of polish, but all JVM tests pass.