### PR TITLE
Adding circe-akka-http project to provide circe support in akka-http

### DIFF
--- a/akkaHttp/README.md
+++ b/akkaHttp/README.md
@@ -1,0 +1,99 @@
+# circe-akka-http
+
+*circe-akka-http* provides support for using *circe* library with
+[akka-http](http://doc.akka.io/docs/akka/current/scala/http/).
+
+## Usage
+By importing `io.circe.akkahttp.JsonSupport._` or `io.circe.akkahttp.ErrorAccumulatingJsonSupport._`
+you can add circe support to your routes.
+
+## Example
+
+### Code
+
+```scala
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.akkahttp.JsonSupport._
+
+object Example extends App with ExampleSupport {
+
+  implicit val actorSystem = ActorSystem("circe-akka-http")
+  implicit val materializer = ActorMaterializer()
+
+  val echoRoute = path("path") {
+    post {
+      entity(as[Request]) { request =>
+        complete(Response(request.requestValue))
+      }
+    }
+  }
+
+  Http().bindAndHandle(echoRoute, "localhost", 8080)
+}
+
+trait ExampleSupport {
+
+  case class Request(requestValue: String)
+  case class Response(responseValue: String)
+
+  implicit val requestDecoder: Decoder[Request] = Decoder.instance[Request] { h =>
+    for {
+      in <- h.downField("requestValue").as[String]
+    } yield {
+      Request(in)
+    }
+  }
+
+  implicit val responseEncoder: Encoder[Response] = Encoder.instance[Response] { response =>
+    Json.obj("responseValue" -> Json.fromString(response.responseValue))
+  }
+}
+```
+
+### Calling with valid json content
+
+```bash
+curl -X POST -H "Content-Type:application/json" -d "{\"requestValue\":\"value\"}" localhost:8080/path -v
+```
+
+```bash
+< HTTP/1.1 200 OK
+< Server: akka-http/2.4.9
+< Content-Type: application/json
+
+{"responseValue":"value"}
+```
+
+### Calling with non json content
+
+```bash
+curl -X POST -H "Content-Type:text/plain" -d "anything" localhost:8080/path -v
+```
+
+```bash
+< HTTP/1.1 415 Unsupported Media Type
+< Server: akka-http/2.4.9
+< Content-Type: text/plain; charset=UTF-8
+
+The request's Content-Type is not supported. Expected: application/json
+```
+
+### Calling with invalid json content
+
+```bash
+curl -X POST -H "Content-Type:application/json" -d "invalid json" localhost:8080/path -v
+```
+
+```bash
+< HTTP/1.1 400 Bad Request
+< Server: akka-http/2.4.9
+< Content-Type: text/plain; charset=UTF-8
+
+The request content was malformed: expected json value got i (line 1, column 1)
+```

--- a/akkaHttp/src/main/scala/io/circe/akkahttp/JsonSupport.scala
+++ b/akkaHttp/src/main/scala/io/circe/akkahttp/JsonSupport.scala
@@ -1,0 +1,60 @@
+package io.circe.akkahttp
+
+import akka.http.scaladsl.marshalling.Marshaller
+import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.util.ByteString
+import cats.data.Validated
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Errors
+import io.circe.Printer
+import io.circe.jawn.decode
+import io.circe.jawn.decodeAccumulating
+
+/**
+  * Provides support for using *circe* library with *akka-http*.
+  *
+  * @author Tamas Polgar
+  */
+trait JsonSupport {
+  def printer: Printer
+
+  implicit final def circeJsonMarshaller[A](implicit encoder: Encoder[A]): ToEntityMarshaller[A] =
+    Marshaller.opaque { value =>
+      HttpEntity(`application/json`, ByteString(printer.pretty(encoder(value))))
+    }
+
+  implicit def circeJsonUnmarshaller[A](implicit decoder: Decoder[A]): FromEntityUnmarshaller[A]
+}
+
+trait FailFastUnmarshaller {
+  this: JsonSupport =>
+  implicit final def circeJsonUnmarshaller[A](implicit decoder: Decoder[A]): FromEntityUnmarshaller[A] =
+    Unmarshaller.byteStringUnmarshaller.forContentTypes(`application/json`).map { byteString =>
+      decode[A](byteString.utf8String).valueOr(throw _)
+    }
+}
+
+trait ErrorAccumulatingUnmarshaller {
+  this: JsonSupport =>
+  implicit final def circeJsonUnmarshaller[A](implicit decoder: Decoder[A]): FromEntityUnmarshaller[A] =
+    Unmarshaller.byteStringUnmarshaller.forContentTypes(`application/json`).map { byteString =>
+      decodeAccumulating[A](byteString.utf8String) match {
+        case Validated.Valid(result) => result
+        case Validated.Invalid(errors) => throw Errors(errors)
+      }
+    }
+}
+
+trait NoSpacesPrinter {
+  this: JsonSupport =>
+  final def printer: Printer = Printer.noSpaces
+}
+
+object JsonSupport extends JsonSupport with NoSpacesPrinter with FailFastUnmarshaller
+
+object ErrorAccumulatingJsonSupport extends JsonSupport with NoSpacesPrinter with ErrorAccumulatingUnmarshaller

--- a/akkaHttp/src/test/scala/io/circe/akkahttp/JsonSupportSpec.scala
+++ b/akkaHttp/src/test/scala/io/circe/akkahttp/JsonSupportSpec.scala
@@ -1,0 +1,72 @@
+package io.circe.akkahttp
+
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.ContentTypes.`text/plain(UTF-8)`
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.server.MalformedRequestContentRejection
+import akka.http.scaladsl.server.UnsupportedRequestContentTypeRejection
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.akkahttp.JsonSupportSpec.echoRoute
+import org.scalatest.FlatSpec
+
+class JsonSupportSpec extends FlatSpec with ScalatestRouteTest {
+
+  "JsonSupport" should "provide unmarshalling and marshalling" in {
+    val validJsonContent = HttpEntity(`application/json`, """{"requestValue":"value"}""")
+
+    Post("/path", validJsonContent) ~> echoRoute ~> check {
+      assert(status === OK)
+      assert(contentType === `application/json`)
+      assert(responseAs[String] === """{"responseValue":"value"}""")
+    }
+  }
+
+  it should "reject contents with non application/json content type" in {
+    val nonJsonContent = HttpEntity(`text/plain(UTF-8)`, "anything")
+
+    Post("/path", nonJsonContent) ~> echoRoute ~> check {
+      assert(rejection === UnsupportedRequestContentTypeRejection(Set(`application/json`)))
+    }
+  }
+
+  it should "reject invalid json contents" in {
+    val invalidJsonContent = HttpEntity(`application/json`, "invalid json")
+
+    Post("/path", invalidJsonContent) ~> echoRoute ~> check {
+      assert(rejection.getClass === classOf[MalformedRequestContentRejection])
+    }
+  }
+}
+
+object JsonSupportSpec {
+
+  case class Request(requestValue: String)
+  case class Response(responseValue: String)
+
+  implicit val requestDecoder: Decoder[Request] = Decoder.instance[Request] { h =>
+    for {
+      in <- h.downField("requestValue").as[String]
+    } yield {
+      Request(in)
+    }
+  }
+
+  implicit val responseEncoder: Encoder[Response] = Encoder.instance[Response] { response =>
+    Json.obj("responseValue" -> Json.fromString(response.responseValue))
+  }
+
+  import akka.http.scaladsl.server.Directives._
+  import io.circe.akkahttp.JsonSupport._
+
+  val echoRoute = path("path") {
+    post {
+      entity(as[Request]) { request =>
+        complete(Response(request.requestValue))
+      }
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   optics,
   scalajs,
   spray,
+  akkaHttp,
   streaming,
   benchmark
 ) ++ (
@@ -437,6 +438,31 @@ lazy val spray = project
   )
   .dependsOn(core, jawn, generic % "test")
 
+lazy val akkaHttp = project
+  .settings(
+    description := "circe akka-http",
+    moduleName := "circe-akka-http"
+  )
+  .settings(allSettings)
+  .settings(
+    libraryDependencies ++=
+      (CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, 11)) => Seq(
+            "com.typesafe.akka" %% "akka-http-experimental" % "2.4.9",
+            "com.typesafe.akka" %% "akka-http-testkit" % "2.4.9" % "test"
+          )
+          case Some((2, 10)) => Seq(
+            "com.typesafe.akka" %% "akka-http-experimental" % "2.0.4",
+            "com.typesafe.akka" %% "akka-http-testkit-experimental" % "2.0.4"
+          )
+          case _ => Nil
+      }) ++ Seq(
+      "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" % "test" cross CrossVersion.full)
+    )
+  )
+  .dependsOn(core, jawn, generic % "test")
+
 lazy val optics = project
   .settings(
     description := "circe optics",
@@ -566,6 +592,7 @@ val jvmProjects = Seq(
   "jawn",
   "jackson",
   "spray",
+  "akkaHttp",
   "benchmark"
 ) ++ (
   if (sys.props("java.specification.version") == "1.8") Seq("java8") else Nil
@@ -576,6 +603,7 @@ val jvmTestProjects = Seq(
   "tests",
   "optics",
   "spray",
+  "akkaHttp",
   "benchmark"
 ) ++ (
   if (sys.props("java.specification.version") == "1.8") Seq("java8") else Nil


### PR DESCRIPTION
Hi,

I'm using circe with akka-http and I thought it would be useful to have akka-http support in circe project. I've forked your project and created a circe-akka-http module. 

I've followed the spray project's JsonSupport interface, however I'm not using RootEncoder/RootDecoder. 

What do you think?

Regards,
Tamas