### PR TITLE
Convert `JNull` to `null` instead of `undefined` in convertJsonToJs

### DIFF
--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -44,7 +44,7 @@ package object scalajs {
     case JNumber(n) => n.toDouble
     case JBoolean(b) => b
     case JArray(arr) => arr.map(convertJsonToJs).toJSArray
-    case JNull => undefined
+    case JNull => null
     case JObject(obj) => obj.toMap.mapValues(convertJsonToJs).toJSDictionary
   }
 


### PR DESCRIPTION
When using `convertJsonToJs` to convert a JSON structure into native JS, it currently converts `JNull` to `undefined`.

This differs from expected behaviour as used in other libraries and as defined in the ECMAScript standard, which specifies that `null` in json should be decoded to `null` [1]

This can be problematic when interacting with existing JS libraries that may be expecting certain values to be passed specifically as `null`, not `undefined. 

(I'm unsure if this is expected circe behaviour and/or if this function was intended to be internal only?)

[1] http://www.ecma-international.org/ecma-262/7.0/index.html#sec-json-object

