### PR TITLE
Add Json#\\.

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Json.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Json.scala
@@ -161,6 +161,28 @@ sealed abstract class Json extends Product with Serializable {
    * Use implementations provided by case classes.
    */
   override def hashCode(): Int
+
+  // Alias for `findAllByKey`.
+  final def \\(key: String): List[Json] = findAllByKey(key)
+
+  /**
+    * Recursively return all values matching the specified `key`.
+    *
+    * The Play docs, from which this method was inspired, reads:
+    *   "Lookup for fieldName in the current object and all descendants."
+    */
+  final def findAllByKey(key: String): List[Json] = keyValues(this).collect {
+    case (k, v) if (k == key) => v
+  }
+
+  private def keyValues(json: Json): List[(String, Json)] = json match {
+    case JObject(obj)  => obj.toList.flatMap { case (k, v) => keyValuesHelper(k, v) }
+    case JArray(elems) => elems.toList.flatMap(keyValues)
+    case _             => Nil
+  }
+
+  private def keyValuesHelper(key: String, value: Json): List[(String, Json)] =
+    (key, value) :: keyValues(value)
 }
 
 final object Json {

--- a/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/JsonSuite.scala
@@ -1,5 +1,6 @@
 package io.circe
 
+import io.circe.Json.{JString, JArray, JNumber, JBoolean, JObject, JNull}
 import io.circe.tests.CirceSuite
 
 class JsonSuite extends CirceSuite {
@@ -12,5 +13,57 @@ class JsonSuite extends CirceSuite {
     val merged = Json.fromFields(fields).deepMerge(reversed)
 
     assert(merged.asObject.map(_.toList) === Some(fields.reverse))
+  }
+
+  val key    = "x"
+  val value1 = "fizz"
+  val value2 = "foobar"
+
+  """findAllByKey and its alias, \\"""  should "return all values matching the given key with key-value pairs at heights 0 and 1." in {
+    val expected = List(JString(value1), JString(value2), JNull)
+    val at0         = (key, JString(value1))
+    val at1         = (key, JString(value2))
+    val at1_2       = (key, JNull)
+    val json        = Json.obj(at0, "y" -> Json.obj(at1), "z" -> Json.obj(at1_2))
+    val result      = json.findAllByKey(key)
+    val resultAlias = json \\ key
+
+    assert(result === expected && resultAlias === expected)
+  }
+
+  """findAllByKey and its alias, \\"""  should "return a List of a single, empty `JObject` for a `Json` with only that (key, value) matching." in {
+    val expected    = List(JObject(JsonObject.empty))
+    val emptyJson   = (key, JObject(JsonObject.empty))
+    val json        = Json.obj(emptyJson)
+    val result      = json.findAllByKey(key)
+    val resultAlias = json \\ key
+
+    assert(result === expected && resultAlias === expected)
+  }
+
+  """findAllByKey and its alias, \\"""  should "return an empty List when used on a `Json` that's not a `JArray` or `JObject`" in {
+    val number  = JNumber(JsonLong(42L))
+    val string  = JString("foobar")
+    val boolean = JBoolean(true)
+    val `null`  = JNull
+
+    val results      = List(number, string, boolean, `null`).map(json => json.findAllByKey("meaninglesskey"))
+    val resultsAlias = List(number, string, boolean, `null`).map(json => json.\\("meaninglesskey"))
+    assert(results.forall(_ == Nil))
+    assert(resultsAlias.forall(_ == Nil))
+  }
+
+  val value3 = 42L
+
+  """findAllByKey and its alias, \\"""  should "return all values matching the given key with key-value pairs at heights  0, 1, and 2." in {
+    val expected    = List(JArray(List(JString(value1))), JString(value2), JNumber(JsonLong(value3)))
+    val `0`         = (key, JArray(List(JString(value1))))
+    val `1`         = (key, JString(value2))
+    val `2`         = (key, JNumber(JsonLong(value3)))
+    val json        = Json.obj(`0`, "y" -> Json.obj(`1`), "z" -> Json.obj(`2`))
+    val result      = json.findAllByKey(key)
+    val resultAlias = json \\ key
+
+    assert(result === expected && resultAlias === expected)
   }
 }


### PR DESCRIPTION
Aims to address https://github.com/travisbrown/circe/issues/256.

```
scala> :paste
// Entering paste mode (ctrl-D to finish)

import io.circe._, io.circe.parser._

val json =
"""{
  "sha": "some sha",
  "parents": [{
    "url": "some url",
    "sha": "some parent sha"
  }]
}"""

val obj = parse(json).right.get


// Exiting paste mode, now interpreting.

// omitted

scala> Json.\\(obj, "sha")
res0: List[io.circe.Json] = List("some sha", "some parent sha")
```

TODO: 
* add tests
* verify that this PR's `Json#\\` aligns with Play's `\\` on multiple tests