### PR TITLE
Fix Scala.js behavior and test

### DIFF
--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -20,7 +20,7 @@ package object scalajs {
     case o: js.Object => Json.fromFields(
       o.asInstanceOf[js.Dictionary[_]].mapValues(unsafeConvertAnyToJson).toSeq
     )
-    case undefined => Json.Null
+    case other if js.isUndefined(other) => Json.Null
   }
 
   /**

--- a/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
+++ b/modules/tests/js/src/test/scala/io/circe/scalajs/ScalaJsSuite.scala
@@ -44,6 +44,6 @@ class ScalaJsSuite extends CirceSuite {
   }
 
   it should "handle undefined js.UndefOr when encoding to js.Object" in {
-    assert(js.isUndefined(UndefOrExample(js.undefined).asJsAny.asInstanceOf[js.Dynamic].name))
+    assert(Option(UndefOrExample(js.undefined).asJsAny.asInstanceOf[js.Dynamic].name).isEmpty)
   }
 }


### PR DESCRIPTION
I merged #376 even though it causes one Scala.js test to fail, and the first change here updates the test to match the new behavior.

The other change causes `convertJsToJson` to fail on unknown types, rather than silently providing a `Json.Null`. This seems reasonable and I'm not sure the older behavior was even intentional (any idea, @chandu0101?).