### PR TITLE
Fix for Decoder[A].validate infinite recursion (#396)

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -118,7 +118,7 @@ trait Decoder[A] extends Serializable { self =>
    */
   final def validate(pred: HCursor => Boolean, message: => String): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Decoder.Result[A] =
-      if (pred(c)) apply(c) else Left(DecodingFailure(message, c.history))
+      if (pred(c)) self(c) else Left(DecodingFailure(message, c.history))
   }
 
   /**

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -255,5 +255,9 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
     assert(decoder.apply(friday.hcursor).isEmpty)
   }
 
+  "validate" should "not infinitely recurse (#396)" in forAll { (i: Int) =>
+    assert(Decoder[Int].validate(_ => true, "whatever").apply(Json.fromInt(i).hcursor) === Right(i))
+  }
+
   checkLaws("Codec[WrappedOptionalField]", CodecTests[WrappedOptionalField].codec)
 }


### PR DESCRIPTION
Should be pretty clear what's been changed 😄 