### PR TITLE
build circe-opticsjs package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -512,12 +512,12 @@ lazy val opticsBase = crossProject.in(file("modules/optics"))
   .settings(allSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "com.github.julien-truffaut" %% "monocle-core" % "1.2.2",
-      "com.github.julien-truffaut" %% "monocle-law" % "1.2.2" % "test",
-      compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-    ),
-    mimaPreviousArtifacts := Set("io.circe" %% "circe-optics" % previousCirceVersion)
+          "com.github.julien-truffaut" %%% "monocle-core" % "1.2.2",
+          "com.github.julien-truffaut" %% "monocle-law" % "1.2.2" % "test",
+          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    )
   )
+  .jvmSettings(mimaPreviousArtifacts := Set("io.circe" %% "circe-optics" % previousCirceVersion))
   .jsSettings(commonJsSettings: _*)
   .jvmConfigure(_.copy(id = "optics"))
   .jsConfigure(_.copy(id = "opticsJS"))

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   tests, testsJS,
   jawn,
   jackson,
-  optics,
+  optics, opticsJS,
   scalajs,
   spray,
   streaming,
@@ -504,12 +504,12 @@ lazy val spray = project.in(file("modules/spray"))
   )
   .dependsOn(core, jawn, generic % "test")
 
-lazy val optics = project.in(file("modules/optics"))
+lazy val opticsBase = crossProject.in(file("modules/optics"))
   .settings(
     description := "circe optics",
     moduleName := "circe-optics"
   )
-  .settings(allSettings)
+  .settings(allSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %% "monocle-core" % "1.2.2",
@@ -518,7 +518,13 @@ lazy val optics = project.in(file("modules/optics"))
     ),
     mimaPreviousArtifacts := Set("io.circe" %% "circe-optics" % previousCirceVersion)
   )
-  .dependsOn(core, tests % "test")
+  .jsSettings(commonJsSettings: _*)
+  .jvmConfigure(_.copy(id = "optics"))
+  .jsConfigure(_.copy(id = "opticsJS"))
+  .dependsOn(coreBase)
+
+lazy val optics = opticsBase.jvm
+lazy val opticsJS = opticsBase.js
 
 lazy val benchmark = project.in(file("modules/benchmark"))
   .settings(


### PR DESCRIPTION
This adds a crossProject definition for circe-optics so that the dervied
scalajs package can be built.

Two things to note. I ran out of heap space trying to run the tests and this is a more complex build.sbt than any I have worked with before, so please pay close attention before merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/travisbrown/circe/402)
<!-- Reviewable:end -->
