### PR TITLE
Better JsonNumber coverage (and related fixes)

### DIFF
--- a/modules/jackson/src/main/scala/io/circe/jackson/package.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/package.scala
@@ -6,6 +6,12 @@ import com.fasterxml.jackson.databind.ObjectWriter
 /**
  * Support for Jackson-powered parsing and printing for circe.
  *
+ * Note that not all guarantees that hold for Jawn-based parsing and the default
+ * printer will hold for the Jackson-based versions. Jackson's handling of
+ * numbers in particular differs significantly: it doesn't distinguish positive
+ * and negative zeros, it may truncate large JSON numbers or simply fail to
+ * parse them, it may print large numbers as strings, etc.
+ *
  * The implementation is ported with minimal changes from Play JSON.
  */
 package object jackson extends WithJacksonMapper with JacksonParser {

--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -70,7 +70,7 @@ sealed abstract class BiggerDecimal extends Serializable {
  *
  * This representation is the same as that used by `java.math.BigDecimal`, with two differences.
  * First, the scale is a `java.math.BigInteger`, not a [[scala.Int]], and the unscaled value will
- * never be an exact power of ten (in order to facilitate comparison).
+ * never be an exact multiple of ten (in order to facilitate comparison).
  */
 private[numbers] final class SigAndExp(
   val unscaled: BigInteger,

--- a/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
+++ b/modules/scalajs/src/main/scala/io/circe/scalajs/package.scala
@@ -2,7 +2,6 @@ package io.circe
 
 import io.circe.Json._
 import scala.scalajs.js
-import scala.scalajs.js.undefined
 import scala.scalajs.js.JSConverters.{ JSRichGenMap, JSRichGenTraversableOnce }
 import scala.util.control.NonFatal
 

--- a/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
+++ b/modules/testing/js/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
@@ -1,0 +1,17 @@
+package io.circe.testing
+
+import io.circe.JsonNumber
+import scala.scalajs.js.JSON
+import scala.util.Try
+
+/**
+ * We only want to generate arbitrary [[JsonNumber]] values that Scala.js can
+ * parse.
+ */
+private[testing] trait ArbitraryJsonNumberTransformer {
+  def transformJsonNumber(n: JsonNumber): JsonNumber =
+    Try(JSON.parse(n.toString): Any).toOption.filter {
+      case x: Double => !x.isInfinite && n.toBigDecimal.exists(_ == BigDecimal(x))
+      case _ => true
+    }.fold(JsonNumber.fromIntegralStringUnsafe("0"))(_ => n)
+}

--- a/modules/testing/jvm/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
+++ b/modules/testing/jvm/src/main/scala/io/circe/testing/ArbitraryJsonNumberTransformer.scala
@@ -1,0 +1,7 @@
+package io.circe.testing
+
+import io.circe.JsonNumber
+
+private[testing] trait ArbitraryJsonNumberTransformer {
+  def transformJsonNumber(n: JsonNumber): JsonNumber = n
+}

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -2,6 +2,7 @@ package io.circe.testing
 
 import cats.data.ValidatedNel
 import io.circe._
+import io.circe.numbers.BiggerDecimal
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -33,9 +34,17 @@ trait ArbitraryInstances extends ShrinkInstances {
   private[this] val genNull: Gen[Json] = Gen.const(Json.Null)
   private[this] val genBool: Gen[Json] = arbitrary[Boolean].map(Json.fromBoolean)
 
-  private[this] val genNumber: Gen[Json] = Gen.oneOf(
-    arbitrary[Long].map(Json.fromLong),
-    arbitrary[Double].map(Json.fromDoubleOrNull)
+  private[this] def genBiggerDecimal: Gen[BiggerDecimal] = Gen.oneOf(
+    Arbitrary.arbitrary[Long].map(BiggerDecimal.fromLong),
+    Arbitrary.arbitrary[Double].map(BiggerDecimal.fromDouble),
+    Arbitrary.arbitrary[BigInt].map(_.bigInteger).map(BiggerDecimal.fromBigInteger),
+    Arbitrary.arbitrary[BigDecimal].map(_.bigDecimal).map(BiggerDecimal.fromBigDecimal)
+  )
+
+  private[this] def genNumber: Gen[Json] = Gen.oneOf(
+    Arbitrary.arbLong.arbitrary.map(Json.fromLong),
+    Arbitrary.arbDouble.arbitrary.map(Json.fromDoubleOrNull),
+    genBiggerDecimal.map(JsonBiggerDecimal.apply).map(Json.fromJsonNumber)
   )
 
   private[this] val genString: Gen[Json] = arbitrary[String].map(Json.fromString)

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ArbitraryInstances.scala
@@ -6,7 +6,7 @@ import io.circe.numbers.BiggerDecimal
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
 
-trait ArbitraryInstances extends ShrinkInstances {
+trait ArbitraryInstances extends ArbitraryJsonNumberTransformer with ShrinkInstances {
   /**
    * The maximum number of values in a generated JSON array.
    */
@@ -40,13 +40,13 @@ trait ArbitraryInstances extends ShrinkInstances {
       arbitrary[BigDecimal].map(JsonBigDecimal(_)),
       arbitrary[Long].map(JsonLong(_)),
       arbitrary[Double].map(d => if (d.isNaN || d.isInfinity) JsonDouble(0.0) else JsonDouble(d))
-    )
+    ).map(transformJsonNumber)
   )
 
   private[this] val genNull: Gen[Json] = Gen.const(Json.Null)
   private[this] val genBool: Gen[Json] = arbitrary[Boolean].map(Json.fromBoolean)
-  private[this] val genNumber: Gen[Json] = Arbitrary.arbitrary[JsonNumber].map(Json.fromJsonNumber)
   private[this] val genString: Gen[Json] = arbitrary[String].map(Json.fromString)
+  private[this] val genNumber: Gen[Json] = Arbitrary.arbitrary[JsonNumber].map(Json.fromJsonNumber)
 
   private[this] def genArray(depth: Int): Gen[Json] = Gen.choose(0, maxJsonArraySize).flatMap { size =>
     Gen.listOfN(

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonInstances.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonInstances.scala
@@ -1,0 +1,65 @@
+package io.circe.jackson
+
+import cats.Eq
+import cats.instances.list._
+import cats.instances.map._
+import io.circe.{
+  Json,
+  JsonBigDecimal,
+  JsonBiggerDecimal,
+  JsonDecimal,
+  JsonDouble,
+  JsonLong,
+  JsonNumber
+}
+import io.circe.Json.{ JArray, JNumber, JObject, JString }
+import io.circe.numbers.BiggerDecimal
+import io.circe.testing.ArbitraryInstances
+import org.scalacheck.Arbitrary
+import scala.util.matching.Regex
+import scala.util.Try
+
+trait JacksonInstances { this: ArbitraryInstances =>
+  /**
+   * Jackson by default in some cases serializes numbers as strings, and we want
+   * to use a [[cats.Eq]] instance that takes that into account when testing.
+   */
+  implicit val eqJsonStringNumber: Eq[Json] = Eq.instance {
+    case ( JArray(a),  JArray(b)) => Eq[List[Json]].eqv(a.toList, b.toList)
+    case (JObject(a), JObject(b)) => Eq[Map[String, Json]].eqv(a.toMap, b.toMap)
+    case (JString(a), JNumber(b)) => a == b.toString
+    case (JNumber(a), JString(b)) => a.toString == b
+    case (a, b) => Json.eqJson.eqv(a, b)
+  }
+
+  private[this] val SigExpPattern: Regex = """[^eE]+[eE][+-]?(\d+)""".r
+  private[this] val replacement: JsonNumber = JsonBiggerDecimal(BiggerDecimal.fromLong(0L))
+
+  /**
+   * Jackson can't handle some very large numbers, so we replace them.
+   *
+   * Ideally it seems like we could set the cap at numbers with exponents larger
+   * than `Int.MaxValue`, but in practice that still results in
+   * `ArithmeticException`.
+   */
+  def cleanNumber(n: JsonNumber): JsonNumber = n.toString match {
+    case SigExpPattern(exp) if !Try(exp.toLong).toOption.exists(_ <= Short.MaxValue.toLong) => replacement
+    case _ => n match {
+      case v @ JsonDecimal(_) => cleanNumber(JsonBiggerDecimal(v.toBiggerDecimal))
+      case v @ JsonBiggerDecimal(value) =>
+        value.toBigDecimal.map(BigDecimal(_)).fold(replacement) { d =>
+          val fromBigDecimal = BiggerDecimal.fromBigDecimal(d.bigDecimal)
+
+          if (fromBigDecimal == value && d.abs <= BigDecimal(Double.MaxValue)) v else JsonBiggerDecimal(fromBigDecimal)
+        }
+      case v @ JsonBigDecimal(_) => v
+      case v @ JsonDouble(_) => v
+      case v @ JsonLong(_) => v
+    }
+  }
+
+  def cleanNumbers(json: Json): Json =
+    json.mapNumber(cleanNumber).mapArray(_.map(cleanNumbers)).mapObject(_.withJsons(cleanNumbers))
+
+  val arbitraryCleanedJson: Arbitrary[Json] = Arbitrary(Arbitrary.arbitrary[Json].map(cleanNumbers))
+}

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
@@ -6,8 +6,8 @@ import io.circe.tests.examples.glossary
 import java.io.File
 import scala.io.Source
 
-class JacksonParserSuite extends CirceSuite {
-  checkLaws("Parser", ParserTests(`package`).parser)
+class JacksonParserSuite extends CirceSuite with JacksonInstances {
+  checkLaws("Parser", ParserTests(`package`).parser(arbitraryCleanedJson))
 
   "parse" should "fail on invalid input" in forAll { (s: String) =>
     assert(parse(s"Not JSON $s").isLeft)

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonPrintingSuite.scala
@@ -3,8 +3,8 @@ package io.circe.jackson
 import io.circe.Json
 import io.circe.tests.CirceSuite
 
-class JacksonPrintingSuite extends CirceSuite {
-  "jacksonPrint" should "produce round-trippable output" in forAll { (json: Json) =>
+class JacksonPrintingSuite extends CirceSuite with JacksonInstances {
+  "jacksonPrint" should "produce round-trippable output" in forAll(arbitraryCleanedJson.arbitrary) { (json: Json) =>
     assert(io.circe.jawn.parse(jacksonPrint(json)) === Right(json))
   }
 }


### PR DESCRIPTION
This PR includes @jeremyrsmith's change from #400 adding `JsonNumber`s created from `BiggerDecimal` to the `Arbitrary` instance for `JsonNumber`.

This change causes some Jackson and Scala.js tests to fail, but for known reasons, so this PR includes updates for the circe-jackson and circe-scalajs tests to take the new `Arbitrary[JsonNumber]` into account.