### PR TITLE
Fixes for two BiggerDecimal bugs

### DIFF
--- a/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
+++ b/modules/numbers/shared/src/main/scala/io/circe/numbers/BiggerDecimal.scala
@@ -155,7 +155,7 @@ final object BiggerDecimal {
   } else {
     val divAndRem = d.divideAndRemainder(BigInteger.TEN)
 
-    if (divAndRem(1) == BigInteger.ZERO) removeTrailingZeros(divAndRem(0), depth + 1) else {
+    if (divAndRem(1) == BigInteger.ZERO) removeTrailingZeros(divAndRem(0), depth + 1L) else {
       new SigAndExp(d, BigInteger.valueOf(-depth))
     }
   }
@@ -171,7 +171,7 @@ final object BiggerDecimal {
 
       new SigAndExp(
         unscaledAndZeros.unscaled,
-        BigInteger.valueOf(d.scale.toLong).subtract(unscaledAndZeros.scale)
+        BigInteger.valueOf(d.scale.toLong).add(unscaledAndZeros.scale)
       )
   }
 
@@ -263,7 +263,7 @@ final object BiggerDecimal {
           case AFTER_DOT =>
             decIndex = i - 1
             if (c == '0') {
-              zeros = 1
+              zeros = zeros + 1
               state = FRACTIONAL
             } else if (c >= '1' && c <= '9') {
               zeros = 0

--- a/modules/tests/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/numbers/BiggerDecimalSuite.scala
@@ -1,7 +1,7 @@
 package io.circe.numbers
 
 import io.circe.testing.{ IntegralString, JsonNumberString }
-import java.math.{ BigDecimal, BigInteger }
+import java.math.BigDecimal
 import org.scalatest.FlatSpec
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import scala.math.{ BigDecimal => SBigDecimal }
@@ -90,6 +90,26 @@ class BiggerDecimalSuite extends FlatSpec with GeneratorDrivenPropertyChecks {
         }
       }
     )
+  }
+
+  it should "agree with parseBiggerDecimalUnsafe" in forAll { (value: SBigDecimal) =>
+    assert(BiggerDecimal.fromBigDecimal(value.bigDecimal) === BiggerDecimal.parseBiggerDecimalUnsafe(value.toString))
+  }
+
+  it should "agree with parseBiggerDecimalUnsafe on multiples of ten with trailing zeros" in {
+    val bigDecimal = new BigDecimal("10.0")
+    val fromBigDecimal = BiggerDecimal.fromBigDecimal(bigDecimal)
+    val fromString = BiggerDecimal.parseBiggerDecimalUnsafe(bigDecimal.toString)
+
+    assert(fromBigDecimal === fromString)
+  }
+
+  it should "work correctly on values whose string representations have exponents larger than Int.MaxValue" in {
+    val bigDecimal = new BigDecimal("-17014118346046923173168730371588410572800E+2147483647")
+    val fromBigDecimal = BiggerDecimal.fromBigDecimal(bigDecimal)
+    val fromString = BiggerDecimal.parseBiggerDecimalUnsafe(bigDecimal.toString)
+
+    assert(fromBigDecimal === fromString)
   }
 
   "fromBigInteger" should "round-trip BigInteger values" in forAll { (value: BigInt) =>


### PR DESCRIPTION
This PR includes fixes for two bugs:

* Constructing a `BiggerDecimal` value from a `BigDecimal` whose string representation has an exponent larger than `Int.MaxValue` results in an incorrect value.
* Multiples of ten with trailing zeros after a decimal point are incorrectly canonicalized, breaking equality.

These bugs will not affect you unless you use `Json.fromBigDecimal` with very large `BigDecimal` values or compare `JsonNumber` values directly (as opposed to decoding number values to standard number types).

I'll backport these fixes for an 0.5.4 release today.