### PR TITLE
Add semi-automatic derivation for ADT enumerations

### DIFF
--- a/modules/generic/shared/src/main/scala/io/circe/generic/decoding/EnumerationDecoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/decoding/EnumerationDecoder.scala
@@ -1,0 +1,34 @@
+package io.circe.generic.decoding
+
+import io.circe.{ Decoder, DecodingFailure, HCursor }
+import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
+import shapeless.labelled.{ field, FieldType }
+
+abstract class EnumerationDecoder[A] extends Decoder[A]
+
+final object EnumerationDecoder {
+  implicit val decodeEnumerationCNil: EnumerationDecoder[CNil] = new EnumerationDecoder[CNil] {
+    def apply(c: HCursor): Decoder.Result[CNil] = Left(DecodingFailure("Enumeration", c.history))
+  }
+
+  implicit def decodeEnumerationCCons[K <: Symbol, V, R <: Coproduct](implicit
+    wit: Witness.Aux[K],
+    gv: LabelledGeneric.Aux[V, HNil],
+    dr: EnumerationDecoder[R]
+  ): EnumerationDecoder[FieldType[K, V] :+: R] = new EnumerationDecoder[FieldType[K, V] :+: R] {
+    def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
+      c.as[String] match {
+        case Right(s) if s == wit.value.name => Right(Inl(field[K](gv.from(HNil))))
+        case Right(_) => dr.apply(c).right.map(Inr(_))
+        case Left(err) => Left(DecodingFailure("Enumeration", c.history))
+      }
+  }
+
+  implicit def decodeEnumeration[A, Repr <: Coproduct](implicit
+    gen: LabelledGeneric.Aux[A, Repr],
+    rr: EnumerationDecoder[Repr]
+  ): EnumerationDecoder[A] =
+    new EnumerationDecoder[A] {
+      def apply(c: HCursor): Decoder.Result[A] = rr(c).right.map(gen.from)
+    }
+}

--- a/modules/generic/shared/src/main/scala/io/circe/generic/encoding/EnumerationEncoder.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/encoding/EnumerationEncoder.scala
@@ -1,0 +1,32 @@
+package io.circe.generic.encoding
+
+import io.circe.{ Encoder, Json }
+import shapeless.{ :+:, CNil, Coproduct, HNil, Inl, Inr, LabelledGeneric, Witness }
+import shapeless.labelled.FieldType
+
+abstract class EnumerationEncoder[A] extends Encoder[A]
+
+final object EnumerationEncoder {
+  implicit val encodeEnumerationCNil: EnumerationEncoder[CNil] = new EnumerationEncoder[CNil] {
+    def apply(a: CNil): Json = sys.error("Cannot encode CNil")
+  }
+
+  implicit def encodeEnumerationCCons[K <: Symbol, V, R <: Coproduct](implicit
+    wit: Witness.Aux[K],
+    gv: LabelledGeneric.Aux[V, HNil],
+    dr: EnumerationEncoder[R]
+  ): EnumerationEncoder[FieldType[K, V] :+: R] = new EnumerationEncoder[FieldType[K, V] :+: R] {
+    def apply(a: FieldType[K, V] :+: R): Json = a match {
+      case Inl(l) => Json.fromString(wit.value.name)
+      case Inr(r) => dr(r)
+    }
+  }
+
+  implicit def encodeEnumeration[A, Repr <: Coproduct](implicit
+    gen: LabelledGeneric.Aux[A, Repr],
+    rr: EnumerationEncoder[Repr]
+  ): EnumerationEncoder[A] =
+    new EnumerationEncoder[A] {
+      def apply(a: A): Json = rr(gen.to(a))
+    }
+}

--- a/modules/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
+++ b/modules/generic/shared/src/main/scala/io/circe/generic/semiauto.scala
@@ -1,8 +1,8 @@
 package io.circe.generic
 
-import io.circe.{ Decoder, ObjectEncoder }
-import io.circe.generic.decoding.DerivedDecoder
-import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.{ Decoder, Encoder, ObjectEncoder }
+import io.circe.generic.decoding.{ DerivedDecoder, EnumerationDecoder }
+import io.circe.generic.encoding.{ DerivedObjectEncoder, EnumerationEncoder }
 import io.circe.generic.util.PatchWithOptions
 import shapeless.{ HList, LabelledGeneric, Lazy }
 import shapeless.ops.function.FnFromProduct
@@ -29,9 +29,23 @@ import shapeless.ops.record.RemoveAll
  */
 final object semiauto {
   final def deriveDecoder[A](implicit decode: Lazy[DerivedDecoder[A]]): Decoder[A] = decode.value
+  final def deriveEncoder[A](implicit encode: Lazy[DerivedObjectEncoder[A]]): ObjectEncoder[A] = encode.value
 
-  final def deriveEncoder[A](implicit encode: Lazy[DerivedObjectEncoder[A]]): ObjectEncoder[A] =
-    encode.value
+  /**
+   * Derive a decoder for a sealed trait hierarchy made up of case objects.
+   *
+   * Note that this differs from the usual derived decoder in that the leaves of
+   * the ADT are represented as JSON strings.
+   */
+  def deriveEnumerationDecoder[A](implicit decode: Lazy[EnumerationDecoder[A]]): Decoder[A] = decode.value
+
+  /**
+   * Derive an encoder for a sealed trait hierarchy made up of case objects.
+   *
+   * Note that this differs from the usual derived encoder in that the leaves of
+   * the ADT are represented as JSON strings.
+   */
+  def deriveEnumerationEncoder[A](implicit encode: Lazy[EnumerationEncoder[A]]): Encoder[A] = encode.value
 
   final def deriveFor[A]: DerivationHelper[A] = new DerivationHelper[A]
 

--- a/modules/tests/shared/src/main/scala/io/circe/tests/examples/CardinalDirection.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/examples/CardinalDirection.scala
@@ -1,0 +1,37 @@
+package io.circe.tests.examples
+
+import cats.Eq
+import org.scalacheck.{ Arbitrary, Gen }
+
+sealed trait CardinalDirection
+case object North extends CardinalDirection
+case object South extends CardinalDirection
+case object East extends CardinalDirection
+case object West extends CardinalDirection
+
+object CardinalDirection {
+  implicit val eqCardinalDirection: Eq[CardinalDirection] = Eq.fromUniversalEquals
+  implicit val arbitraryCardinalDirection: Arbitrary[CardinalDirection] = Arbitrary(
+    Gen.oneOf(North, South, East, West)
+  )
+}
+
+sealed trait ExtendedCardinalDirection
+case object North2 extends ExtendedCardinalDirection
+case object South2 extends ExtendedCardinalDirection
+case object East2 extends ExtendedCardinalDirection
+case object West2 extends ExtendedCardinalDirection
+case class NotACardinalDirectionAtAll(x: String) extends ExtendedCardinalDirection
+
+object ExtendedCardinalDirection {
+  implicit val eqExtendedCardinalDirection: Eq[ExtendedCardinalDirection] = Eq.fromUniversalEquals
+  implicit val arbitraryExtendedCardinalDirection: Arbitrary[ExtendedCardinalDirection] = Arbitrary(
+    Gen.oneOf(
+      Gen.const(North2),
+      Gen.const(South2),
+      Gen.const(East2),
+      Gen.const(West2),
+      Arbitrary.arbitrary[String].map(NotACardinalDirectionAtAll(_))
+    )
+  )
+}

--- a/modules/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/generic/SemiautoDerivedSuite.scala
@@ -24,6 +24,9 @@ class SemiautoDerivedSuite extends CirceSuite {
   implicit val decodeFoo: Decoder[Foo] = deriveDecoder
   implicit val encodeFoo: ObjectEncoder[Foo] = deriveEncoder
 
+  implicit val decodeCardinalDirection: Decoder[CardinalDirection] = deriveEnumerationDecoder
+  implicit val encodeCardinalDirection: Encoder[CardinalDirection] = deriveEnumerationEncoder
+
   implicit val decodeIntlessQux: Decoder[Int => Qux[String]] =
     deriveFor[Int => Qux[String]].incomplete
 
@@ -82,6 +85,7 @@ class SemiautoDerivedSuite extends CirceSuite {
   checkLaws("Codec[Box[Int]]", CodecTests[Box[Int]].codec)
   checkLaws("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
   checkLaws("Codec[Foo]", CodecTests[Foo].codec)
+  checkLaws("Codec[CardinalDirection]", CodecTests[CardinalDirection].codec)
   checkLaws("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)
   checkLaws("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].codec)
 
@@ -145,5 +149,13 @@ class SemiautoDerivedSuite extends CirceSuite {
     illTyped("deriveDecoder[OvergenerationExampleInner1]")
     illTyped("deriveEncoder[OvergenerationExampleInner0]")
     illTyped("deriveEncoder[OvergenerationExampleInner1]")
+  }
+
+  "deriveEnumerationDecoder" should "not compile on an ADT with case classes" in {
+    illTyped("deriveEnumerationDecoder[ExtendedCardinalDirection]")
+  }
+
+  "deriveEnumerationEncoder" should "not compile on an ADT with case classes" in {
+    illTyped("deriveEnumerationEncoder[ExtendedCardinalDirection]")
   }
 }


### PR DESCRIPTION
Currently the derived codecs for case objects result in either an empty object, or a field with an empty object value, depending on whether the value is statically typed as an ADT leaf or root:

``` scala
scala> import io.circe.generic.auto._, io.circe.syntax._
import io.circe.generic.auto._
import io.circe.syntax._

scala> sealed trait Base; case object Foo extends Base
defined trait Base
defined object Foo

scala> Foo.asJson.noSpaces
res0: String = {}

scala> (Foo: Base).asJson.noSpaces
res1: String = {"Foo":{}}
```

This will probably always be the default behavior, since it's always safe and unambiguous, and since having derived encoders that return JSON values that aren't objects complicates things significantly.

There is a common use case for case objects that can be pretty easily supported, though. If we're defining an enumeration as a sealed trait of case objects, we often want the values to be represented as strings. This PR adds support for this representation to `io.circe.semiauto`:

``` scala
import io.circe.{ Decoder, Encoder }
import io.circe.generic.semiauto.{ deriveEnumerationDecoder, deriveEnumerationEncoder }
import io.circe.jawn._, io.circe.syntax._

sealed trait Suit extends Product with Serializable
case object Club extends Suit
case object Heart extends Suit
case object Spade extends Suit
case object Diamond extends Suit

object Suit {
  implicit val decodeSuit: Decoder[Suit] = deriveEnumerationDecoder
  implicit val encodeSuit: Encoder[Suit] = deriveEnumerationEncoder
}
```

And then:

``` scala
scala> decode[Suit]("\"Club\"")
res0: Either[io.circe.Error,Suit] = Right(Club)

scala> List(Heart, Club, Diamond).asJson
res1: io.circe.Json =
[
  "Heart",
  "Club",
  "Diamond"
]
```

If we had any case classes that extended `Suit`, the derivation would fail to compile.

Note that this must be explicitly invoked via `deriveEnumerationX`, and will not collide with any automatically derived decoders.
