### PR TITLE
Add circe-shapeless module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ def noDocProjects(sv: String): Seq[ProjectReference] = Seq[ProjectReference](
   java8,
   literalJS,
   genericJS,
+  shapelessJS,
   numbersJS,
   opticsJS,
   parserJS,
@@ -119,6 +120,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   numbers, numbersJS,
   core, coreJS,
   generic, genericJS,
+  shapeless, shapelessJS,
   literal, literalJS,
   refined, refinedJS,
   parser, parserJS,
@@ -243,6 +245,24 @@ lazy val genericBase = crossProject.in(file("modules/generic"))
 
 lazy val generic = genericBase.jvm
 lazy val genericJS = genericBase.js
+
+lazy val shapelessBase = crossProject.crossType(CrossType.Pure).in(file("modules/shapeless"))
+  .settings(
+    description := "circe shapeless",
+    moduleName := "circe-shapeless",
+    name := "shapeless"
+  )
+  .settings(allSettings: _*)
+  .settings(macroDependencies: _*)
+  .settings(
+    libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion
+  )
+  .jvmConfigure(_.copy(id = "shapeless"))
+  .jsConfigure(_.copy(id = "shapelessJS"))
+  .dependsOn(coreBase)
+
+lazy val shapeless = shapelessBase.jvm
+lazy val shapelessJS = shapelessBase.js
 
 lazy val literalBase = crossProject.crossType(CrossType.Pure).in(file("modules/literal"))
   .settings(
@@ -395,6 +415,7 @@ lazy val testsBase = crossProject.in(file("modules/tests"))
     testingBase,
     coreBase,
     genericBase,
+    shapelessBase,
     literalBase,
     refinedBase,
     parserBase,
@@ -620,6 +641,7 @@ val jvmProjects = Seq(
   "numbers",
   "core",
   "generic",
+  "shapeless",
   "refined",
   "parser",
   "scodec",
@@ -646,6 +668,7 @@ val jsProjects = Seq(
   "numbersJS",
   "coreJS",
   "genericJS",
+  "shapelessJS",
   "opticsJS",
   "parserJS",
   "refinedJS",

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/HListInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/HListInstances.scala
@@ -1,0 +1,48 @@
+package io.circe.shapeless
+
+import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, HCursor, Json, JsonObject, ObjectEncoder }
+import shapeless.{ ::, HList, HNil }
+
+trait HListInstances extends LowPriorityHListInstances {
+  implicit final def decodeSingletonHList[H](implicit decodeH: Decoder[H]): Decoder[H :: HNil] =
+    Decoder[Tuple1[H]].map(t => t._1 :: HNil).withErrorMessage("HList")
+
+  implicit final def encodeSingletonHList[H](implicit encodeH: Encoder[H]): ArrayEncoder[H :: HNil] =
+    new ArrayEncoder[H :: HNil] {
+      def encodeArray(a: H :: HNil): List[Json] = List(encodeH(a.head))
+    }
+}
+
+private[shapeless] trait LowPriorityHListInstances {
+  implicit final val decodeHNil: Decoder[HNil] = Decoder.const(HNil)
+  implicit final val encodeHNil: ObjectEncoder[HNil] = new ObjectEncoder[HNil] {
+    def encodeObject(a: HNil): JsonObject = JsonObject.empty
+  }
+
+  implicit final def decodeHCons[H, T <: HList](implicit
+    decodeH: Decoder[H],
+    decodeT: Decoder[T]
+  ): Decoder[H :: T] = new Decoder[H :: T] {
+    def apply(c: HCursor): Decoder.Result[H :: T] = {
+      val first = c.downArray
+
+      Decoder.resultInstance.map2(first.as(decodeH), decodeT.tryDecode(first.delete))(_ :: _)
+    }
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[H :: T] = {
+      val first = c.downArray
+
+      AccumulatingDecoder.resultInstance.map2(
+        decodeH.tryDecodeAccumulating(first),
+        decodeT.tryDecodeAccumulating(first.delete)
+      )(_ :: _)
+    }
+  }
+
+  implicit final def encodeHCons[H, T <: HList](implicit
+    encodeH: Encoder[H],
+    encodeT: ArrayEncoder[T]
+  ): ArrayEncoder[H :: T] = new ArrayEncoder[H :: T] {
+      def encodeArray(a: H :: T): List[Json] = encodeH(a.head) +: encodeT.encodeArray(a.tail)
+  }
+}

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/RecordInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/RecordInstances.scala
@@ -1,0 +1,100 @@
+package io.circe.shapeless
+
+import cats.Eq
+import cats.data.Validated
+import io.circe.{
+  AccumulatingDecoder,
+  Decoder,
+  DecodingFailure,
+  Encoder,
+  HCursor,
+  JsonObject,
+  KeyDecoder,
+  KeyEncoder,
+  ObjectEncoder
+}
+import shapeless.{ ::, HList, Widen, Witness }
+import shapeless.labelled.{ field, FieldType }
+
+trait RecordInstances extends LowPriorityRecordInstances {
+  /**
+   * Decode a record element with a symbol key.
+   *
+   * This is provided as a special case because of type inference issues with
+   * `decodeRecord` for symbols.
+   */
+  implicit final def decodeSymbolRecordCons[K <: Symbol, V, T <: HList](implicit
+    witK: Witness.Aux[K],
+    decodeV: Decoder[V],
+    decodeT: Decoder[T]
+  ): Decoder[FieldType[K, V] :: T] = new Decoder[FieldType[K, V] :: T] {
+    def apply(c: HCursor): Decoder.Result[FieldType[K, V] :: T] = Decoder.resultInstance.map2(
+      c.get[V](witK.value.name),
+      decodeT(c)
+    )((h, t) => field[K](h) :: t)
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[FieldType[K, V] :: T] =
+      AccumulatingDecoder.resultInstance.map2(
+        decodeV.tryDecodeAccumulating(c.downField(witK.value.name)),
+        decodeT.decodeAccumulating(c)
+      )((h, t) => field[K](h) :: t)
+  }
+
+  /**
+   * Encode a record element with a symbol key.
+   *
+   * This is provided as a special case because of type inference issues with
+   * `encodeRecord` for symbols.
+   */
+  implicit final def encodeSymbolRecordCons[K <: Symbol, V, T <: HList](implicit
+    witK: Witness.Aux[K],
+    encodeV: Encoder[V],
+    encodeT: ObjectEncoder[T]
+  ): ObjectEncoder[FieldType[K, V] :: T] = new ObjectEncoder[FieldType[K, V] :: T] {
+    def encodeObject(a: FieldType[K, V] :: T): JsonObject =
+      encodeT.encodeObject(a.tail).add(witK.value.name, encodeV(a.head))
+  }
+}
+
+private[shapeless] trait LowPriorityRecordInstances extends HListInstances {
+  implicit final def decodeRecordCons[K, W >: K, V, T <: HList](implicit
+    widenK: Widen.Aux[K, W],
+    witK: Witness.Aux[K],
+    eqW: Eq[W],
+    decodeW: KeyDecoder[W],
+    decodeV: Decoder[V],
+    decodeT: Decoder[T]
+  ): Decoder[FieldType[K, V] :: T] = new Decoder[FieldType[K, V] :: T] {
+    private[this] val widened = widenK(witK.value)
+
+    def apply(c: HCursor): Decoder.Result[FieldType[K, V] :: T] = Decoder.resultInstance.map2(
+        c.fields.flatMap(
+          _.find(key => decodeW(key).exists(w => eqW.eqv(w, widened)))
+        ).fold[Decoder.Result[String]](Left(DecodingFailure("Record", c.history)))(Right(_)).right.flatMap(c.get[V](_)),
+      decodeT(c)
+    )((h, t) => field[K](h) :: t)
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[FieldType[K, V] :: T] =
+      AccumulatingDecoder.resultInstance.map2(
+        c.fields.flatMap(
+          _.find(key => decodeW(key).exists(w => eqW.eqv(w, widened)))
+        ).fold[AccumulatingDecoder.Result[String]](
+          Validated.invalidNel(DecodingFailure("Record", c.history))
+        )(Validated.valid(_)).andThen(k => decodeV.tryDecodeAccumulating(c.downField(k))),
+        decodeT.decodeAccumulating(c)
+      )((h, t) => field[K](h) :: t)
+  }
+
+  implicit final def encodeRecordCons[K, W >: K, V, T <: HList](implicit
+    widenK: Widen.Aux[K, W],
+    witK: Witness.Aux[K],
+    encodeW: KeyEncoder[W],
+    encodeV: Encoder[V],
+    encodeT: ObjectEncoder[T]
+  ): ObjectEncoder[FieldType[K, V] :: T] = new ObjectEncoder[FieldType[K, V] :: T] {
+    private[this] val widened = widenK(witK.value)
+
+    def encodeObject(a: FieldType[K, V] :: T): JsonObject =
+      encodeT.encodeObject(a.tail).add(encodeW(widened), encodeV(a.head))
+  }
+}

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/SizedInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/SizedInstances.scala
@@ -1,0 +1,41 @@
+package io.circe.shapeless
+
+import cats.data.Validated
+import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, Encoder, HCursor }
+import scala.collection.GenTraversable
+import shapeless.{ AdditiveCollection, Nat, Sized }
+import shapeless.ops.nat.ToInt
+
+trait SizedInstances {
+  implicit final def decodeSized[L <: Nat, C[X] <: GenTraversable[X], A](implicit
+    decodeCA: Decoder[C[A]],
+    ev: AdditiveCollection[C[A]],
+    toInt: ToInt[L]
+  ): Decoder[Sized[C[A], L]] = new Decoder[Sized[C[A], L]] {
+    private[this] def checkSize(coll: C[A]): Option[Sized[C[A], L]] =
+      if (coll.size == toInt()) Some(Sized.wrap[C[A], L](coll)) else None
+
+    private[this] def failure(c: HCursor): DecodingFailure = DecodingFailure(s"Sized[C[A], _${toInt()}]", c.history)
+
+    def apply(c: HCursor): Decoder.Result[Sized[C[A], L]] =
+      decodeCA(c) match {
+        case Right(as) => checkSize(as) match {
+          case Some(s) => Right(s)
+          case None => Left(failure(c))
+        }
+        case l @ Left(_) => l.asInstanceOf[Decoder.Result[Sized[C[A], L]]]
+      }
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[Sized[C[A], L]] =
+      decodeCA.decodeAccumulating(c) match {
+        case Validated.Valid(as) => checkSize(as) match {
+          case Some(s) => Validated.valid(s)
+          case None => Validated.invalidNel(failure(c))
+        }
+        case l @ Validated.Invalid(_) => l.asInstanceOf[AccumulatingDecoder.Result[Sized[C[A], L]]]
+      }
+  }
+
+  implicit def encodeSized[L <: Nat, C[_], A](implicit encodeCA: Encoder[C[A]]): Encoder[Sized[C[A], L]] =
+    encodeCA.contramap(_.unsized)
+}

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
@@ -1,0 +1,3 @@
+package io.circe
+
+package object shapeless extends RecordInstances with SizedInstances

--- a/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
+++ b/modules/tests/shared/src/main/scala/io/circe/tests/MissingInstances.scala
@@ -3,7 +3,10 @@ package io.circe.tests
 import cats.Eq
 import java.util.UUID
 import org.scalacheck.{ Arbitrary, Gen }
-import shapeless._
+import org.scalacheck.util.Buildable
+import shapeless.{ ::, AdditiveCollection, Generic, HList, HNil, IsTuple, Nat, Sized }
+import shapeless.labelled.{ field, FieldType }
+import shapeless.ops.nat.ToInt
 
 trait MissingInstances {
   implicit lazy val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
@@ -23,7 +26,7 @@ trait MissingInstances {
 
   implicit lazy val eqHNil: Eq[HNil] = Eq.instance((_, _) => true)
 
-  implicit def eqTupleHCons[H, T <: HList](implicit eqH: Eq[H], eqT: Eq[T]): Eq[H :: T] =
+  implicit def eqHCons[H, T <: HList](implicit eqH: Eq[H], eqT: Eq[T]): Eq[H :: T] =
     Eq.instance[H :: T] {
       case (h1 :: t1, h2 :: t2) => eqH.eqv(h1, h2) && eqT.eqv(t1, t2)
     }
@@ -32,4 +35,30 @@ trait MissingInstances {
     gen: Generic.Aux[P, L],
     eqL: Eq[L]
   ): Eq[P] = eqL.on(gen.to)
+
+  implicit lazy val arbitraryHNil: Arbitrary[HNil] = Arbitrary(Gen.const(HNil))
+
+  implicit def arbitraryHCons[H, T <: HList](implicit H: Arbitrary[H], T: Arbitrary[T]): Arbitrary[H :: T] =
+    Arbitrary(
+      for {
+        h <- H.arbitrary
+        t <- T.arbitrary
+      } yield h :: t
+    )
+
+  implicit def eqFieldType[K, V](implicit V: Eq[V]): Eq[FieldType[K, V]] = V.on(identity)
+
+  implicit def arbitraryFieldType[K, V](implicit V: Arbitrary[V]): Arbitrary[FieldType[K, V]] =
+    Arbitrary(V.arbitrary.map(field[K](_)))
+
+  implicit def eqSized[L <: Nat, C[_], A](implicit CA: Eq[C[A]]): Eq[Sized[C[A], L]] = CA.on(_.unsized)
+
+  implicit def arbitrarySized[L <: Nat, C[_], A](implicit
+    A: Arbitrary[A],
+    additive: AdditiveCollection[C[A]],
+    buildable: Buildable[A, C[A]],
+    ev: C[A] => Traversable[A],
+    toInt: ToInt[L]
+  ): Arbitrary[Sized[C[A], L]] =
+    Arbitrary(Gen.containerOfN[C, A](toInt(), A.arbitrary).filter(_.size == toInt()).map(Sized.wrap[C[A], L]))
 }

--- a/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
@@ -1,0 +1,52 @@
+package io.circe.shapeless
+
+import io.circe.Decoder
+import io.circe.literal._
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceSuite
+import shapeless.{ ::, HNil, Nat, Sized }
+import shapeless.record.Record
+import shapeless.syntax.singleton._
+
+class ShapelessSuite extends CirceSuite {
+  checkLaws("Codec[HNil]", CodecTests[HNil].codec)
+  checkLaws("Codec[Int :: HNil]", CodecTests[Int :: HNil].codec)
+  checkLaws("Codec[String :: Int :: HNil]", CodecTests[String :: Int :: HNil].codec)
+  checkLaws("Codec[Record.`'foo -> String, 'bar -> Int`.T]", CodecTests[Record.`'foo -> String, 'bar -> Int`.T].codec)
+  checkLaws(
+    """Codec[Record.`"a" -> Char, "b" -> Int, "c" -> Char`.T]""",
+    CodecTests[Record.`"a" -> Char, "b" -> Int, "c" -> Char`.T].codec
+  )
+  checkLaws("Codec[Sized[List[Int], Nat._4]]", CodecTests[Sized[List[Int], Nat._4]].codec)
+  checkLaws("Codec[Sized[Vector[String], Nat._10]]", CodecTests[Sized[Vector[String], Nat._10]].codec)
+
+  val hlistDecoder = Decoder[String :: Int :: List[Char] :: HNil]
+
+  "An hlist decoder" should "decode an array as an hlist" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
+    val expected = foo :: bar :: baz :: HNil
+    val result = hlistDecoder.decodeJson(json"""[ $foo, $bar, $baz ]""")
+
+    assert(result === Right(expected))
+  }
+
+  it should "accumulated errors" in forAll { (foo: String, bar: Int, baz: List[Char]) =>
+    val result = hlistDecoder.accumulating(json"""[ $foo, $baz, $bar ]""".hcursor)
+
+    assert(result.swap.exists(_.size == 2))
+  }
+
+  val recordDecoder = Decoder[Record.`'foo -> String, 'bar -> Int`.T]
+
+  "A record decoder" should "decode an object as a record" in forAll { (foo: String, bar: Int) =>
+    val expected = 'foo ->> foo :: 'bar ->> bar :: HNil
+    val result = recordDecoder.decodeJson(json"""{ "foo": $foo, "bar": $bar }""")
+
+    assert(result === Right(expected))
+  }
+
+  it should "accumulated errors" in forAll { (foo: String, bar: Int) =>
+    val result = recordDecoder.accumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
+
+    assert(result.swap.exists(_.size == 2))
+  }
+}

--- a/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
@@ -1,6 +1,6 @@
 package io.circe.shapeless
 
-import io.circe.Decoder
+import io.circe.{ Decoder, Encoder }
 import io.circe.literal._
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
@@ -46,6 +46,21 @@ class ShapelessSuite extends CirceSuite {
 
   it should "accumulated errors" in forAll { (foo: String, bar: Int) =>
     val result = recordDecoder.accumulating(json"""{ "foo": $bar, "bar": $foo }""".hcursor)
+
+    assert(result.swap.exists(_.size == 2))
+  }
+
+  val sizedDecoder = Decoder[Sized[List[Int], Nat._4]]
+
+  "A Sized decoder" should "fail if given an incorrect number of elements" in forAll { (xs: List[Int]) =>
+    val values = if (xs.size == 4) xs ++ xs else xs
+    val result = sizedDecoder.decodeJson(Encoder[List[Int]].apply(values))
+
+    assert(result.isLeft)
+  }
+
+  it should "accumulated errors" in forAll { (a: Int, b: String, c: Int, d: String) =>
+    val result = sizedDecoder.accumulating(json"""[ $a, $b, $c, $d ]""".hcursor)
 
     assert(result.swap.exists(_.size == 2))
   }


### PR DESCRIPTION
This is a new module that provides encoders and decoders for Shapeless's hlists, records, and `Sized` collections.