### PR TITLE
Decoder#or should accumulate failures when using decodeAccumulating

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -55,6 +55,9 @@ final object AccumulatingDecoder {
   final val resultInstance: ApplicativeError[Result, NonEmptyList[DecodingFailure]] =
     Validated.catsDataInstancesForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
 
+  private[circe] val resultSemigroupK: SemigroupK[Result] =
+    Validated.catsDataSemigroupKForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
+
   /**
    * Return an instance for a given type.
    */

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -144,6 +144,9 @@ trait Decoder[A] extends Serializable { self =>
       case r @ Right(_) => r
       case Left(_) => d(c)
     }
+
+    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[AA] =
+      AccumulatingDecoder.resultSemigroupK.combineK(self.decodeAccumulating(c), d.decodeAccumulating(c))
   }
 
   /**
@@ -242,7 +245,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
 
   type Result[A] = Either[DecodingFailure, A]
 
-  val resultInstance: MonadError[Result, DecodingFailure] = catsStdInstancesForEither[DecodingFailure]
+  val resultInstance: MonadError[Result, DecodingFailure] =
+    catsStdInstancesForEither[DecodingFailure]
 
   private[this] abstract class DecoderWithFailure[A](name: String) extends Decoder[A] {
     final def fail(c: HCursor): Result[A] = Left(DecodingFailure(name, c.history))


### PR DESCRIPTION
Inspired by the discussion [here](https://github.com/typelevel/cats/pull/1448), this change makes decoders built with `or` accumulate errors if error accumulation is requested.