### PR TITLE
Add coproduct decoders

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/AccumulatingDecoder.scala
@@ -55,9 +55,6 @@ final object AccumulatingDecoder {
   final val resultInstance: ApplicativeError[Result, NonEmptyList[DecodingFailure]] =
     Validated.catsDataInstancesForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
 
-  private[circe] val resultSemigroupK: SemigroupK[Result] =
-    Validated.catsDataSemigroupKForValidated[NonEmptyList[DecodingFailure]](failureNelInstance)
-
   /**
    * Return an instance for a given type.
    */

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -144,9 +144,6 @@ trait Decoder[A] extends Serializable { self =>
       case r @ Right(_) => r
       case Left(_) => d(c)
     }
-
-    override def decodeAccumulating(c: HCursor): AccumulatingDecoder.Result[AA] =
-      AccumulatingDecoder.resultSemigroupK.combineK(self.decodeAccumulating(c), d.decodeAccumulating(c))
   }
 
   /**
@@ -245,8 +242,7 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
 
   type Result[A] = Either[DecodingFailure, A]
 
-  val resultInstance: MonadError[Result, DecodingFailure] =
-    catsStdInstancesForEither[DecodingFailure]
+  val resultInstance: MonadError[Result, DecodingFailure] = catsStdInstancesForEither[DecodingFailure]
 
   private[this] abstract class DecoderWithFailure[A](name: String) extends Decoder[A] {
     final def fail(c: HCursor): Result[A] = Left(DecodingFailure(name, c.history))

--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -2,7 +2,7 @@ package io.circe
 
 import cats.{ MonadError, SemigroupK }
 import cats.data.{ Kleisli, NonEmptyList, NonEmptyVector, OneAnd, StateT, Validated }
-import cats.instances.either.catsStdInstancesForEither
+import cats.instances.either.{ catsDataSemigroupKForEither, catsStdInstancesForEither }
 import io.circe.export.Exported
 import java.util.UUID
 import scala.annotation.tailrec
@@ -243,6 +243,8 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   type Result[A] = Either[DecodingFailure, A]
 
   val resultInstance: MonadError[Result, DecodingFailure] = catsStdInstancesForEither[DecodingFailure]
+
+  private[circe] val resultSemigroupK: SemigroupK[Result] = catsDataSemigroupKForEither[DecodingFailure]
 
   private[this] abstract class DecoderWithFailure[A](name: String) extends Decoder[A] {
     final def fail(c: HCursor): Result[A] = Left(DecodingFailure(name, c.history))

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/CoproductInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/CoproductInstances.scala
@@ -1,6 +1,6 @@
 package io.circe.shapeless
 
-import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, JsonObject }
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json }
 import shapeless.{ :+:, CNil, Coproduct, Inl, Inr }
 
 trait CoproductInstances {

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/CoproductInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/CoproductInstances.scala
@@ -1,0 +1,29 @@
+package io.circe.shapeless
+
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, JsonObject }
+import shapeless.{ :+:, CNil, Coproduct, Inl, Inr }
+
+trait CoproductInstances {
+  implicit final val decodeCNil: Decoder[CNil] = new Decoder[CNil] {
+    def apply(c: HCursor): Decoder.Result[CNil] = Left(DecodingFailure("CNil", c.history))
+  }
+
+  implicit final val encodeCNil: Encoder[CNil] = new Encoder[CNil] {
+    def apply(a: CNil): Json = sys.error("Cannot encode CNil")
+  }
+
+  implicit final def decodeCCons[L, R <: Coproduct](implicit
+    decodeL: Decoder[L],
+    decodeR: Decoder[R]
+  ): Decoder[L :+: R] = decodeL.map(Inl(_)).or(decodeR.map(Inr(_)))
+
+  implicit final def encodeCCons[L, R <: Coproduct](implicit
+    encodeL: Encoder[L],
+    encodeR: Encoder[R]
+  ): Encoder[L :+: R] = new Encoder[L :+: R] {
+    def apply(a: L :+: R): Json = a match {
+      case Inl(l) => encodeL(l)
+      case Inr(r) => encodeR(r)
+    }
+  }
+}

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledCoproductInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledCoproductInstances.scala
@@ -1,0 +1,77 @@
+package io.circe.shapeless
+
+import cats.Eq
+import cats.data.{ NonEmptyList, Validated }
+import io.circe.{
+  AccumulatingDecoder,
+  Decoder,
+  DecodingFailure,
+  Encoder,
+  HCursor,
+  Json,
+  KeyDecoder,
+  KeyEncoder
+}
+import shapeless.{ :+:, Coproduct, Inl, Inr, Widen, Witness }
+import shapeless.labelled.{ field, FieldType }
+
+trait LabelledCoproductInstances extends LowPriorityLabelledCoproductInstances {
+  implicit final def decodeSymbolLabelledCCons[K <: Symbol, V, R <: Coproduct](implicit
+    witK: Witness.Aux[K],
+    decodeV: Decoder[V],
+    decodeR: Decoder[R]
+  ): Decoder[FieldType[K, V] :+: R] = new Decoder[FieldType[K, V] :+: R] {
+    def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
+      Decoder.resultSemigroupK.combineK(
+        c.get[V](witK.value.name).right.map(v => Inl(field[K](v))),
+        decodeR(c).right.map(Inr(_))
+      )
+  }
+
+  implicit final def encodeSymbolLabelledCCons[K <: Symbol, V, R <: Coproduct](implicit
+    witK: Witness.Aux[K],
+    encodeV: Encoder[V],
+    encodeR: Encoder[R]
+  ): Encoder[FieldType[K, V] :+: R] = new Encoder[FieldType[K, V] :+: R] {
+    def apply(a: FieldType[K, V] :+: R): Json = a match {
+      case Inl(l) => Json.obj(witK.value.name -> encodeV(l))
+      case Inr(r) => encodeR(r)
+    }
+  }
+}
+
+private[shapeless] trait LowPriorityLabelledCoproductInstances extends CoproductInstances {
+  implicit final def decodeLabelledCCons[K, W >: K, V, R <: Coproduct](implicit
+    witK: Witness.Aux[K],
+    widenK: Widen.Aux[K, W],
+    eqW: Eq[W],
+    decodeW: KeyDecoder[W],
+    decodeV: Decoder[V],
+    decodeR: Decoder[R]
+  ): Decoder[FieldType[K, V] :+: R] = new Decoder[FieldType[K, V] :+: R] {
+    private[this] val widened = widenK(witK.value)
+    private[this] val isK: String => Boolean = decodeW(_).exists(eqW.eqv(widened, _))
+
+    def apply(c: HCursor): Decoder.Result[FieldType[K, V] :+: R] =
+      Decoder.resultSemigroupK.combineK(
+        c.fields.flatMap(_.find(isK)).fold[Decoder.Result[String]](
+          Left(DecodingFailure("Record", c.history))
+        )(Right(_)).right.flatMap(c.get[V](_).right.map(v => Inl(field[K](v)))),
+        decodeR(c).right.map(Inr(_))
+      )
+  }
+
+  implicit final def encodeLabelledCCons[K, W >: K, V, R <: Coproduct](implicit
+    witK: Witness.Aux[K],
+    eqW: Eq[W],
+    encodeW: KeyEncoder[W],
+    encodeV: Encoder[V],
+    encodeR: Encoder[R]
+  ): Encoder[FieldType[K, V] :+: R] = new Encoder[FieldType[K, V] :+: R] {
+    def apply(a: FieldType[K, V] :+: R): Json = a match {
+      case Inl(l) => Json.obj(encodeW(witK.value) -> encodeV(l))
+      case Inr(r) => encodeR(r)
+    }
+  }
+}
+

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledCoproductInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledCoproductInstances.scala
@@ -1,17 +1,7 @@
 package io.circe.shapeless
 
 import cats.Eq
-import cats.data.{ NonEmptyList, Validated }
-import io.circe.{
-  AccumulatingDecoder,
-  Decoder,
-  DecodingFailure,
-  Encoder,
-  HCursor,
-  Json,
-  KeyDecoder,
-  KeyEncoder
-}
+import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, KeyDecoder, KeyEncoder }
 import shapeless.{ :+:, Coproduct, Inl, Inr, Widen, Witness }
 import shapeless.labelled.{ field, FieldType }
 

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledHListInstances.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/LabelledHListInstances.scala
@@ -16,14 +16,14 @@ import io.circe.{
 import shapeless.{ ::, HList, Widen, Witness }
 import shapeless.labelled.{ field, FieldType }
 
-trait RecordInstances extends LowPriorityRecordInstances {
+trait LabelledHListInstances extends LowPriorityLabelledHListInstances {
   /**
    * Decode a record element with a symbol key.
    *
    * This is provided as a special case because of type inference issues with
    * `decodeRecord` for symbols.
    */
-  implicit final def decodeSymbolRecordCons[K <: Symbol, V, T <: HList](implicit
+  implicit final def decodeSymbolLabelledHCons[K <: Symbol, V, T <: HList](implicit
     witK: Witness.Aux[K],
     decodeV: Decoder[V],
     decodeT: Decoder[T]
@@ -46,7 +46,7 @@ trait RecordInstances extends LowPriorityRecordInstances {
    * This is provided as a special case because of type inference issues with
    * `encodeRecord` for symbols.
    */
-  implicit final def encodeSymbolRecordCons[K <: Symbol, V, T <: HList](implicit
+  implicit final def encodeSymbolLabelledHCons[K <: Symbol, V, T <: HList](implicit
     witK: Witness.Aux[K],
     encodeV: Encoder[V],
     encodeT: ObjectEncoder[T]
@@ -56,8 +56,8 @@ trait RecordInstances extends LowPriorityRecordInstances {
   }
 }
 
-private[shapeless] trait LowPriorityRecordInstances extends HListInstances {
-  implicit final def decodeRecordCons[K, W >: K, V, T <: HList](implicit
+private[shapeless] trait LowPriorityLabelledHListInstances extends HListInstances {
+  implicit final def decodeLabelledHCons[K, W >: K, V, T <: HList](implicit
     witK: Witness.Aux[K],
     widenK: Widen.Aux[K, W],
     eqW: Eq[W],
@@ -84,7 +84,7 @@ private[shapeless] trait LowPriorityRecordInstances extends HListInstances {
       )((h, t) => field[K](h) :: t)
   }
 
-  implicit final def encodeRecordCons[K, W >: K, V, T <: HList](implicit
+  implicit final def encodeLabelledHCons[K, W >: K, V, T <: HList](implicit
     witK: Witness.Aux[K],
     widenK: Widen.Aux[K, W],
     encodeW: KeyEncoder[W],

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
@@ -1,3 +1,4 @@
 package io.circe
 
-package object shapeless extends RecordInstances with LabelledCoproductInstances with SizedInstances
+package object shapeless extends LabelledHListInstances with LabelledCoproductInstances
+  with SizedInstances

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
@@ -1,3 +1,3 @@
 package io.circe
 
-package object shapeless extends RecordInstances with SizedInstances
+package object shapeless extends RecordInstances with LabelledCoproductInstances with SizedInstances

--- a/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapeless/ShapelessSuite.scala
@@ -4,7 +4,8 @@ import io.circe.{ Decoder, Encoder }
 import io.circe.literal._
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceSuite
-import shapeless.{ ::, HNil, Nat, Sized }
+import shapeless.{ :+:, ::, CNil, HNil, Nat, Sized, Witness }
+import shapeless.labelled.FieldType
 import shapeless.record.Record
 import shapeless.syntax.singleton._
 
@@ -16,6 +17,15 @@ class ShapelessSuite extends CirceSuite {
   checkLaws(
     """Codec[Record.`"a" -> Char, "b" -> Int, "c" -> Char`.T]""",
     CodecTests[Record.`"a" -> Char, "b" -> Int, "c" -> Char`.T].codec
+  )
+  checkLaws("Codec[Int :+: String :+: List[Char] :+: CNil]", CodecTests[String :+: Int :+: List[Char] :+: CNil].codec)
+  checkLaws(
+    "Codec[FieldType[Witness.`'foo`.T, Int] :+: FieldType[Witness.`'bar`.T, String] :+: CNil]",
+    CodecTests[FieldType[Witness.`'foo`.T, Int] :+: FieldType[Witness.`'bar`.T, String] :+: CNil].codec
+  )
+  checkLaws(
+    """Codec[FieldType[Witness.`"a"`.T, Int] :+: FieldType[Witness.`"b"`.T, String] :+: CNil]""",
+    CodecTests[FieldType[Witness.`"a"`.T, Int] :+: FieldType[Witness.`"b"`.T, String] :+: CNil].codec
   )
   checkLaws("Codec[Sized[List[Int], Nat._4]]", CodecTests[Sized[List[Int], Nat._4]].codec)
   checkLaws("Codec[Sized[Vector[String], Nat._10]]", CodecTests[Sized[Vector[String], Nat._10]].codec)


### PR DESCRIPTION
As discussed in #439, this PR adds `Encoder` and `Decoder` instances for Shapeless's coproducts (both labelled and unlabelled). It also renames the `Record` codecs (to `LabelledHList`) for consistency with the new instances.

This PR also reverts yesterday's related #440, which allowed inconsistencies between fail-fast and error-accumulating decoders:

```scala
scala> import io.circe.Decoder, io.circe.jawn.{ decode, decodeAccumulating }
import io.circe.Decoder
import io.circe.jawn.{decode, decodeAccumulating}

scala> val d = Decoder[Int].map[Either[Int, String]](Left(_)).or(
     |   Decoder[String].map[Either[Int, String]](Right(_))
     | )
d: io.circe.Decoder[Either[Int,String]] = io.circe.Decoder$$anon$19@20425b88

scala> println(decode("null")(d))
Left(DecodingFailure(String, List()))

scala> println(decodeAccumulating("null")(d).leftMap(_.head))
Invalid(DecodingFailure(Int, List()))
```

In the context of this PR, this also means if you try to decode a coproduct with error accumulation, you'll only see a single failure (not one for each constructor).