### PR TITLE
Add decodeX and encodeX convenience methods

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/Decoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Decoder.scala
@@ -666,6 +666,18 @@ final object Decoder extends TupleDecoders with ProductDecoders with LowPriority
   /**
    * @group Decoding
    */
+  implicit final def decodeList[A: Decoder]: Decoder[List[A]] =
+    decodeCanBuildFrom[A, List].withErrorMessage("[A]List[A]")
+
+  /**
+   * @group Decoding
+   */
+  implicit final def decodeVector[A: Decoder]: Decoder[Vector[A]] =
+    decodeCanBuildFrom[A, Vector].withErrorMessage("[A]Vector[A]")
+
+  /**
+   * @group Decoding
+   */
   implicit final def decodeOneAnd[A, C[_]](implicit
     da: Decoder[A],
     cbf: CanBuildFrom[Nothing, A, C[A]]

--- a/modules/core/shared/src/main/scala/io/circe/Encoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/Encoder.scala
@@ -230,6 +230,21 @@ object Encoder extends TupleEncoders with ProductEncoders with MidPriorityEncode
   /**
    * @group Encoding
    */
+  implicit final def encodeSet[A: Encoder]: Encoder[Set[A]] = encodeTraversableOnce[A, Set]
+
+  /**
+   * @group Encoding
+   */
+  implicit final def encodeList[A: Encoder]: Encoder[List[A]] = encodeTraversableOnce[A, List]
+
+  /**
+   * @group Encoding
+   */
+  implicit final def encodeVector[A: Encoder]: Encoder[Vector[A]] = encodeTraversableOnce[A, Vector]
+
+  /**
+   * @group Encoding
+   */
   implicit final def encodeNonEmptyList[A](implicit e: Encoder[A]): Encoder[NonEmptyList[A]] =
     new ArrayEncoder[NonEmptyList[A]] {
       final def encodeArray(a: NonEmptyList[A]): List[Json] = a.toList.map(e(_))

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -294,4 +294,16 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
   }
 
   checkLaws("Codec[WrappedOptionalField]", CodecTests[WrappedOptionalField].codec)
+
+  "decodeSet" should "match sequence decoders" in forAll { (xs: List[Int]) =>
+    assert(Decoder.decodeSet[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toSet).decodeJson(xs.asJson))
+  }
+
+  "decodeList" should "match sequence decoders" in forAll { (xs: List[Int]) =>
+    assert(Decoder.decodeList[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toList).decodeJson(xs.asJson))
+  }
+
+  "decodeVector" should "match sequence decoders" in forAll { (xs: List[Int]) =>
+    assert(Decoder.decodeVector[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toVector).decodeJson(xs.asJson))
+  }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/EncoderSuite.scala
@@ -26,4 +26,16 @@ class EncoderSuite extends CirceSuite {
     val decoder = Decoder.enumDecoder(WeekDay)
     assert(decoder.apply(json.hcursor) == Right(WeekDay.Fri))
   }
+
+  "encodeSet" should "match sequence encoders" in forAll { (xs: Set[Int]) =>
+    assert(Encoder.encodeSet[Int].apply(xs) === Encoder[Seq[Int]].apply(xs.toSeq))
+  }
+
+  "encodeList" should "match sequence encoders" in forAll { (xs: List[Int]) =>
+    assert(Encoder.encodeList[Int].apply(xs) === Encoder[Seq[Int]].apply(xs))
+  }
+
+  "encodeVector" should "match sequence encoders" in forAll { (xs: Vector[Int]) =>
+    assert(Encoder.encodeVector[Int].apply(xs) === Encoder[Seq[Int]].apply(xs))
+  }
 }


### PR DESCRIPTION
This has come up a few times (most recently [here](https://gitter.im/travisbrown/circe?at=58200adbb4046d90642c6e5c)). It's often the case that someone wants e.g. to decode a JSON array using a custom, non-implicit decoder for the element type. This is currently somewhat inconvenient—you have to write something like this:

```scala
import io.circe.Decoder

val decodeA = Decoder[String].prepare(_.downField("a"))

val decodeX =
  Decoder.decodeCanBuildFrom[String, List](decodeA, implicitly).prepare(_.downField("x"))
```

This PR adds new `decodeList`, `decodeVector`, `encodeSet`, `encodeList`, and `encodeVector` methods to allow people to avoid the `decodeCanBuildFrom ... implicitly` nonsense.

Note that these instances are implicit, but not ambiguous, since they have more specific return types than `decodeCanBuildFrom` and `encodeTraversable`.