### PR TITLE
Rename shapeless module to shapes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ def noDocProjects(sv: String): Seq[ProjectReference] = Seq[ProjectReference](
   literalJS,
   genericJS,
   genericExtrasJS,
-  shapelessJS,
+  shapesJS,
   numbersJS,
   opticsJS,
   parserJS,
@@ -123,7 +123,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq[ProjectReference](
   core, coreJS,
   generic, genericJS,
   genericExtras, genericExtrasJS,
-  shapeless, shapelessJS,
+  shapes, shapesJS,
   literal, literalJS,
   refined, refinedJS,
   parser, parserJS,
@@ -277,11 +277,11 @@ lazy val genericExtrasBase = crossProject.crossType(CrossType.Pure).in(file("mod
 lazy val genericExtras = genericExtrasBase.jvm
 lazy val genericExtrasJS = genericExtrasBase.js
 
-lazy val shapelessBase = crossProject.crossType(CrossType.Pure).in(file("modules/shapeless"))
+lazy val shapesBase = crossProject.crossType(CrossType.Pure).in(file("modules/shapes"))
   .settings(
-    description := "circe shapeless",
-    moduleName := "circe-shapeless",
-    name := "shapeless",
+    description := "circe shapes",
+    moduleName := "circe-shapes",
+    name := "shapes",
     crossScalaVersions := scalaVersions
   )
   .settings(allSettings: _*)
@@ -289,12 +289,12 @@ lazy val shapelessBase = crossProject.crossType(CrossType.Pure).in(file("modules
   .settings(
     libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion
   )
-  .jvmConfigure(_.copy(id = "shapeless"))
-  .jsConfigure(_.copy(id = "shapelessJS"))
+  .jvmConfigure(_.copy(id = "shapes"))
+  .jsConfigure(_.copy(id = "shapesJS"))
   .dependsOn(coreBase)
 
-lazy val shapeless = shapelessBase.jvm
-lazy val shapelessJS = shapelessBase.js
+lazy val shapes = shapesBase.jvm
+lazy val shapesJS = shapesBase.js
 
 lazy val literalBase = crossProject.crossType(CrossType.Pure).in(file("modules/literal"))
   .settings(
@@ -455,7 +455,7 @@ lazy val testsBase = crossProject.in(file("modules/tests"))
     coreBase,
     genericBase,
     genericExtrasBase,
-    shapelessBase,
+    shapesBase,
     literalBase,
     refinedBase,
     parserBase,
@@ -677,7 +677,7 @@ val jvmProjects = Seq(
   "core",
   "generic",
   "genericExtras",
-  "shapeless",
+  "shapes",
   "refined",
   "parser",
   "scodec",
@@ -700,7 +700,7 @@ val jsProjects = Seq(
   "coreJS",
   "genericJS",
   "genericExtrasJS",
-  "shapelessJS",
+  "shapesJS",
   "opticsJS",
   "parserJS",
   "refinedJS",

--- a/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
+++ b/modules/shapeless/src/main/scala/io/circe/shapeless/package.scala
@@ -1,4 +1,0 @@
-package io.circe
-
-package object shapeless extends LabelledHListInstances with LabelledCoproductInstances
-  with SizedInstances

--- a/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json }
 import shapeless.{ :+:, CNil, Coproduct, Inl, Inr }

--- a/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/HListInstances.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import io.circe.{ AccumulatingDecoder, ArrayEncoder, Decoder, Encoder, HCursor, Json, JsonObject, ObjectEncoder }
 import shapeless.{ ::, HList, HNil }
@@ -13,7 +13,7 @@ trait HListInstances extends LowPriorityHListInstances {
     }
 }
 
-private[shapeless] trait LowPriorityHListInstances {
+private[shapes] trait LowPriorityHListInstances {
   implicit final val decodeHNil: Decoder[HNil] = Decoder.const(HNil)
   implicit final val encodeHNil: ObjectEncoder[HNil] = new ObjectEncoder[HNil] {
     def encodeObject(a: HNil): JsonObject = JsonObject.empty

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledCoproductInstances.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import cats.Eq
 import io.circe.{ Decoder, DecodingFailure, Encoder, HCursor, Json, KeyDecoder, KeyEncoder }
@@ -30,7 +30,7 @@ trait LabelledCoproductInstances extends LowPriorityLabelledCoproductInstances {
   }
 }
 
-private[shapeless] trait LowPriorityLabelledCoproductInstances extends CoproductInstances {
+private[shapes] trait LowPriorityLabelledCoproductInstances extends CoproductInstances {
   implicit final def decodeLabelledCCons[K, W >: K, V, R <: Coproduct](implicit
     witK: Witness.Aux[K],
     widenK: Widen.Aux[K, W],

--- a/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/LabelledHListInstances.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import cats.Eq
 import cats.data.Validated
@@ -56,7 +56,7 @@ trait LabelledHListInstances extends LowPriorityLabelledHListInstances {
   }
 }
 
-private[shapeless] trait LowPriorityLabelledHListInstances extends HListInstances {
+private[shapes] trait LowPriorityLabelledHListInstances extends HListInstances {
   implicit final def decodeLabelledHCons[K, W >: K, V, T <: HList](implicit
     witK: Witness.Aux[K],
     widenK: Widen.Aux[K, W],

--- a/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/SizedInstances.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import cats.data.Validated
 import io.circe.{ AccumulatingDecoder, Decoder, DecodingFailure, Encoder, HCursor }

--- a/modules/shapes/src/main/scala/io/circe/shapes/package.scala
+++ b/modules/shapes/src/main/scala/io/circe/shapes/package.scala
@@ -1,0 +1,4 @@
+package io.circe
+
+package object shapes extends LabelledHListInstances with LabelledCoproductInstances
+  with SizedInstances

--- a/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/shapes/ShapelessSuite.scala
@@ -1,4 +1,4 @@
-package io.circe.shapeless
+package io.circe.shapes
 
 import io.circe.{ Decoder, Encoder }
 import io.circe.literal._


### PR DESCRIPTION
Okay, I've relented—putting a `_root_` tax on anyone who has a circe-shapeless dependency and imports `io.circe._` isn't really very nice, so I've renamed the module to circe-shapes, and all instances are in the `io.circe.shapes` package.