### PR TITLE
Correct scaladoc on KeyDecoder#apply.

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
+++ b/modules/core/shared/src/main/scala/io/circe/KeyDecoder.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
  */
 abstract class KeyDecoder[A] extends Serializable { self =>
   /**
-   * Convert a value to String.
+   * Attempt to convert a String to a value.
    */
   def apply(key: String): Option[A]
 


### PR DESCRIPTION
I think the scaladoc had gotten copied from `KeyEncoder`. This just uses a more correct phrasing.