### PR TITLE
Make history stack safe again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -278,6 +278,9 @@ lazy val genericExtrasBase = crossProject.crossType(CrossType.Pure).in(file("mod
       }
     )
   )
+  .jvmSettings(
+    mimaPreviousArtifacts := Set("io.circe" %% "circe-generic-extras" % previousCirceVersion)
+  )
   .jvmConfigure(_.copy(id = "genericExtras"))
   .jsConfigure(_.copy(id = "genericExtrasJS"))
   .dependsOn(genericBase)
@@ -296,6 +299,9 @@ lazy val shapesBase = crossProject.crossType(CrossType.Pure).in(file("modules/sh
   .settings(macroDependencies: _*)
   .settings(
     libraryDependencies += "com.chuusai" %%% "shapeless" % shapelessVersion
+  )
+  .jvmSettings(
+    mimaPreviousArtifacts := Set("io.circe" %% "circe-shapes" % previousCirceVersion)
   )
   .jvmConfigure(_.copy(id = "shapes"))
   .jsConfigure(_.copy(id = "shapesJS"))
@@ -419,6 +425,9 @@ lazy val testingBase = crossProject.in(file("modules/testing"))
   )
   .settings(
     coverageExcludedPackages := "io\\.circe\\.testing\\..*"
+  )
+  .jvmSettings(
+    mimaPreviousArtifacts := Set("io.circe" %% "circe-testing" % previousCirceVersion)
   )
   .dependsOn(coreBase)
 

--- a/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/DecoderSuite.scala
@@ -306,4 +306,12 @@ class DecoderSuite extends CirceSuite with LargeNumberDecoderTests {
   "decodeVector" should "match sequence decoders" in forAll { (xs: List[Int]) =>
     assert(Decoder.decodeVector[Int].decodeJson(xs.asJson) === Decoder[Seq[Int]].map(_.toVector).decodeJson(xs.asJson))
   }
+
+  "HCursor#history" should "be stack safe" in {
+    val size = 10000
+    val json = List.fill(size)(1).asJson.mapArray(_ :+ true.asJson)
+    val Left(DecodingFailure(_, history)) = Decoder[List[Int]].decodeJson(json)
+
+    assert(history.size === size + 1)
+  }
 }


### PR DESCRIPTION
If you're trying to decode a long JSON array and an error happens several thousand elements in (on my machine around 6,500), requesting the operation history isn't stack safe:

```scala
scala> import io.circe.jawn.decode, io.circe.syntax._
import io.circe.jawn.decode
import io.circe.syntax._

scala> val json = List.fill(10000)(1).asJson.mapArray(_ :+ true.asJson).noSpaces
json: String = [1,1,1,1,1,1,1,1,1,1,1...

scala> decode[List[Int]](json)
java.lang.StackOverflowError
  at io.circe.HCursor$$anon$3.history(HCursor.scala:48)
  at io.circe.HCursor$$anon$3.history(HCursor.scala:48)
  ...
```

This is my fault—it's the result of a clumsy attempt at optimization several releases ago. The problem is that instantiating the history lazily actually does help performance quite a bit (like 15% more throughput in our benchmarks). The fix here attempts to have its cake and eat it too by keeping track of the depth of the history and forcing it to be evaluated when it gets too deep—arbitrarily (and somewhat conservatively) at 1,024 elements.

This means that people who are decoding large JSON arrays may see a performance hit, but given the fact that it's not that terrible (and that to my knowledge nobody has actually run into the stack safety bug on large JSON arrays), I think that's a reasonable price to pay.

The way that history is tracked will be revisited in #228, which will probably happen in 0.8.0. In the meantime I think this is a reasonable workaround, and I'll be publishing an 0.6.1 later today or tomorrow.