### PR TITLE
Introduce decodeByteBuffer, decodeFile, decodeByteArray

### DIFF
--- a/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
+++ b/modules/jackson/src/main/scala/io/circe/jackson/JacksonParser.scala
@@ -1,6 +1,7 @@
 package io.circe.jackson
 
-import io.circe.{ Json, Parser, ParsingFailure }
+import cats.data.ValidatedNel
+import io.circe.{ Decoder, Error, Json, Parser, ParsingFailure }
 import java.io.File
 import scala.util.control.NonFatal
 
@@ -22,4 +23,16 @@ trait JacksonParser extends Parser { this: WithJacksonMapper =>
   } catch {
     case NonFatal(error) => Left(ParsingFailure(error.getMessage, error))
   }
+
+  final def decodeByteArray[A: Decoder](bytes: Array[Byte]): Either[Error, A] =
+    finishDecode[A](parseByteArray(bytes))
+
+  final def decodeByteArrayAccumulating[A: Decoder](bytes: Array[Byte]): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseByteArray(bytes))
+
+  final def decodeFile[A: Decoder](file: File): Either[Error, A] =
+    finishDecode[A](parseFile(file))
+
+  final def decodeFileAccumulating[A: Decoder](file: File): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseFile(file))
 }

--- a/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/JawnParser.scala
@@ -1,6 +1,7 @@
 package io.circe.jawn
 
-import io.circe.{ Json, Parser, ParsingFailure }
+import cats.data.ValidatedNel
+import io.circe.{ Decoder, Error, Json, Parser, ParsingFailure }
 import java.io.File
 import java.nio.ByteBuffer
 import scala.util.{ Failure, Success, Try }
@@ -19,4 +20,16 @@ class JawnParser extends Parser {
 
   final def parseByteBuffer(buffer: ByteBuffer): Either[ParsingFailure, Json] =
     fromTry(CirceSupportParser.parseFromByteBuffer(buffer))
+
+  final def decodeByteBuffer[A: Decoder](buffer: ByteBuffer): Either[Error, A] =
+    finishDecode[A](parseByteBuffer(buffer))
+
+  final def decodeByteBufferAccumulating[A: Decoder](buffer: ByteBuffer): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseByteBuffer(buffer))
+
+  final def decodeFile[A: Decoder](file: File): Either[Error, A] =
+    finishDecode[A](parseFile(file))
+
+  final def decodeFileAccumulating[A: Decoder](file: File): ValidatedNel[Error, A] =
+    finishDecodeAccumulating[A](parseFile(file))
 }

--- a/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
+++ b/modules/testing/shared/src/main/scala/io/circe/testing/ParserTests.scala
@@ -1,31 +1,65 @@
 package io.circe.testing
 
+import cats.data.{ Validated, ValidatedNel }
 import cats.instances.either._
 import cats.laws._
 import cats.laws.discipline._
-import io.circe.{ Json, Parser, ParsingFailure }
+import io.circe.{ Error, Json, Parser, ParsingFailure }
 import org.scalacheck.{ Arbitrary, Prop }
 import org.typelevel.discipline.Laws
 
-case class ParserLaws(parser: Parser) {
-  def parsingRoundTripNoSpaces(json: Json): IsEq[Either[ParsingFailure, Json]] =
-    parser.parse(json.noSpaces) <-> Right(json)
+case class ParserLaws[P <: Parser](parser: P) {
+  def parsingRoundTrip[A](json: Json)(
+    encode: Json => A, decode: P => (A => Either[ParsingFailure, Json])
+  ): IsEq[Either[ParsingFailure, Json]] =
+    decode(parser)(encode(json)) <-> Right(json)
 
-  def parsingRoundTripSpaces(json: Json): IsEq[Either[ParsingFailure, Json]] =
-    parser.parse(json.spaces2) <-> Right(json)
+  def decodingRoundTrip[A](json: Json)(
+    encode: Json => A, decode: P => (A => Either[Error, Json])
+  ): IsEq[Either[Error, Json]] =
+    decode(parser)(encode(json)) <-> Right(json)
+
+  def decodingAccumulatingRoundTrip[A](json: Json)(
+    encode: Json => A, decode: P => (A => ValidatedNel[Error, Json])
+  ): IsEq[ValidatedNel[Error, Json]] =
+    decode(parser)(encode(json)) <-> Validated.valid(json)
 }
 
-case class ParserTests(p: Parser) extends Laws {
-  def laws: ParserLaws = ParserLaws(p)
+case class ParserTests[P <: Parser](p: P) extends Laws {
+  def laws: ParserLaws[P] = ParserLaws(p)
 
-  def parser(implicit arbitraryJson: Arbitrary[Json]): RuleSet = new DefaultRuleSet(
-    name = "parser",
+  def fromString(implicit arbitraryJson: Arbitrary[Json]): RuleSet =
+    fromFunction[String]("fromString")(
+      identity, _.parse, _.decode[Json], _.decodeAccumulating[Json]
+    )
+
+  def fromFunction[A](name: String)(
+    serialize: String => A,
+    parse: P => A => Either[ParsingFailure, Json],
+    decode: P => A => Either[Error, Json],
+    decodeAccumulating: P => A => ValidatedNel[Error, Json]
+  )(implicit arbitraryJson: Arbitrary[Json]): RuleSet = new DefaultRuleSet(
+    name = s"parser[$name]",
     parent = None,
-    "roundTripWithoutSpaces" -> Prop.forAll { (json: Json) =>
-      laws.parsingRoundTripNoSpaces(json)
+    "parsingRoundTripWithoutSpaces" -> Prop.forAll { (json: Json) =>
+      laws.parsingRoundTrip[A](json)(json => serialize(json.noSpaces), parse)
     },
-    "roundTripWithSpaces" -> Prop.forAll { (json: Json) =>
-      laws.parsingRoundTripSpaces(json)
+    "parsingRoundTripWithSpaces" -> Prop.forAll { (json: Json) =>
+      laws.parsingRoundTrip[A](json)(json => serialize(json.spaces2), parse)
+    },
+    "decodingRoundTripWithoutSpaces" -> Prop.forAll { (json: Json) =>
+      laws.decodingRoundTrip[A](json)(json => serialize(json.noSpaces), decode)
+    },
+    "decodingRoundTripWithSpaces" -> Prop.forAll { (json: Json) =>
+      laws.decodingRoundTrip[A](json)(json => serialize(json.spaces2), decode)
+    },
+    "decodingAccumualtingRoundTripWithoutSpaces" -> Prop.forAll { (json: Json) =>
+      laws.decodingAccumulatingRoundTrip[A](json)(json =>
+        serialize(json.noSpaces), decodeAccumulating)
+    },
+    "decodingAccumualtingRoundTripWithSpaces" -> Prop.forAll { (json: Json) =>
+      laws.decodingAccumulatingRoundTrip[A](json)(json =>
+        serialize(json.spaces2), decodeAccumulating)
     }
   )
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jackson/JacksonParserSuite.scala
@@ -1,5 +1,7 @@
 package io.circe.jackson
 
+import cats.data.Validated
+import io.circe.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 import io.circe.tests.examples.glossary
@@ -7,25 +9,39 @@ import java.io.File
 import scala.io.Source
 
 class JacksonParserSuite extends CirceSuite with JacksonInstances {
-  checkLaws("Parser", ParserTests(`package`).parser(arbitraryCleanedJson))
+  checkLaws("Parser", ParserTests(`package`).fromString(arbitraryCleanedJson))
+  checkLaws("Parser", ParserTests(`package`)
+    .fromFunction[Array[Byte]]("fromByteArray")(
+      s => s.getBytes("UTF-8"),
+      p => p.parseByteArray _,
+      p => p.decodeByteArray[Json] _,
+      p => p.decodeByteArrayAccumulating[Json] _
+    )(arbitraryCleanedJson)
+  )
 
-  "parse" should "fail on invalid input" in forAll { (s: String) =>
+  "parse and decode(Accumulating)" should "fail on invalid input" in forAll { (s: String) =>
     assert(parse(s"Not JSON $s").isLeft)
+    assert(decode[Json](s"Not JSON $s").isLeft)
+    assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
   }
 
-  "parseFile" should "parse a JSON file" in {
+  "parseFile and decodeFile(Accumulating)" should "parse a JSON file" in {
     val url = getClass.getResource("/io/circe/tests/examples/glossary.json")
     val file = new File(url.toURI)
 
+    assert(decodeFile[Json](file) === Right(glossary))
+    assert(decodeFileAccumulating[Json](file) == Validated.valid(glossary))
     assert(parseFile(file) === Right(glossary))
   }
 
-  "parseByteArray" should "parse an array of bytes" in {
+  "parseByteArray and decodeByteArray(Accumulating)" should "parse an array of bytes" in {
     val stream = getClass.getResourceAsStream("/io/circe/tests/examples/glossary.json")
     val source = Source.fromInputStream(stream)
     val bytes = source.map(_.toByte).toArray
     source.close()
 
+    assert(decodeByteArray[Json](bytes) === Right(glossary))
+    assert(decodeByteArrayAccumulating[Json](bytes) === Validated.valid(glossary))
     assert(parseByteArray(bytes) === Right(glossary))
   }
 }

--- a/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
+++ b/modules/tests/jvm/src/test/scala/io/circe/jawn/JawnParserSuite.scala
@@ -1,5 +1,7 @@
 package io.circe.jawn
 
+import cats.data.Validated
+import io.circe.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 import io.circe.tests.examples.glossary
@@ -8,27 +10,39 @@ import java.nio.ByteBuffer
 import scala.io.Source
 
 class JawnParserSuite extends CirceSuite {
-  checkLaws("Parser", ParserTests(`package`).parser)
+  checkLaws("Parser", ParserTests(`package`).fromString)
+  checkLaws("Parser", ParserTests(`package`)
+    .fromFunction[ByteBuffer]("fromByteBuffer")(
+      s => ByteBuffer.wrap(s.getBytes("UTF-8")),
+      p => p.parseByteBuffer _,
+      p => p.decodeByteBuffer[Json] _,
+      p => p.decodeByteBufferAccumulating[Json] _
+    )
+  )
 
-  "parse" should "fail on invalid input" in forAll { (s: String) =>
+  "parse and decode(Accumulating)" should "fail on invalid input" in forAll { (s: String) =>
     assert(parse(s"Not JSON $s").isLeft)
+    assert(decode[Json](s"Not JSON $s").isLeft)
+    assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
   }
 
-  "parseFile" should "parse a JSON file" in {
+  "parseFile and decodeFile(Accumulating)" should "parse a JSON file" in {
     val url = getClass.getResource("/io/circe/tests/examples/glossary.json")
     val file = new File(url.toURI)
 
+    assert(decodeFile[Json](file) === Right(glossary))
+    assert(decodeFileAccumulating[Json](file) == Validated.valid(glossary))
     assert(parseFile(file) === Right(glossary))
   }
 
-  "parseByteBuffer" should "parse a byte buffer" in {
+  "parseByteBuffer and decodeByteBuffer(Accumulating)" should "parse a byte buffer" in {
     val stream = getClass.getResourceAsStream("/io/circe/tests/examples/glossary.json")
     val source = Source.fromInputStream(stream)
     val bytes = source.map(_.toByte).toArray
     source.close()
 
-    val buffer = ByteBuffer.wrap(bytes)
-
-    assert(parseByteBuffer(buffer) === Right(glossary))
+    assert(decodeByteBuffer[Json](ByteBuffer.wrap(bytes)) === Right(glossary))
+    assert(decodeByteBufferAccumulating[Json](ByteBuffer.wrap(bytes)) == Validated.valid(glossary))
+    assert(parseByteBuffer(ByteBuffer.wrap(bytes)) === Right(glossary))
   }
 }

--- a/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
+++ b/modules/tests/shared/src/test/scala/io/circe/parser/ParserSuite.scala
@@ -1,12 +1,15 @@
 package io.circe.parser
 
+import io.circe.Json
 import io.circe.testing.ParserTests
 import io.circe.tests.CirceSuite
 
 class ParserSuite extends CirceSuite {
-  checkLaws("Parser", ParserTests(`package`).parser)
+  checkLaws("Parser", ParserTests(`package`).fromString)
 
-  "parse" should "fail on invalid input" in forAll { (s: String) =>
+  "parse and decode(Accumulating)" should "fail on invalid input" in forAll { (s: String) =>
     assert(parse(s"Not JSON $s").isLeft)
+    assert(decode[Json](s"Not JSON $s").isLeft)
+    assert(decodeAccumulating[Json](s"Not JSON $s").isInvalid)
   }
 }


### PR DESCRIPTION
Circe supported parsers (Jawn, Jackson) provide meanings for parsing from byte arrays and byte buffers (which is super nice for things like https://github.com/finagle/finch/pull/671). Although, the `decodeX` API doesn't support anything but `String` as an input. While it's totally possible to drop down to the `parseX` variant and do decoding as a separate step, having a single entry point method (i.e., `decodeX`) for may both simplify the call-site and reduce some unnecessary allocations.

This PR introduces `decodeX` variants into both parsers for decoding from `ByteBuffer`s, `File`s, and `Array[Byte]`s.

Please, let me know if this requires some testing - I'm happy to add those respectively.