### PR TITLE
Use builders that allow us to avoid rebuilding

### DIFF
--- a/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
+++ b/modules/core/shared/src/main/scala/io/circe/JsonObject.scala
@@ -141,6 +141,9 @@ final object JsonObject {
    */
   final def fromMap(m: Map[String, Json]): JsonObject = MapAndVectorJsonObject(m, m.keys.toVector)
 
+  private[circe] final def fromMapAndVector(m: Map[String, Json], keys: Vector[String]): JsonObject =
+    MapAndVectorJsonObject(m, keys)
+
   /**
    * Construct an empty [[JsonObject]].
    */

--- a/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
+++ b/modules/jawn/src/main/scala/io/circe/jawn/CirceSupportParser.scala
@@ -1,8 +1,7 @@
 package io.circe.jawn
 
-import io.circe.{ Json, JsonNumber }
+import io.circe.{ Json, JsonNumber, JsonObject }
 import jawn.{ Facade, FContext, SupportParser }
-import scala.collection.mutable.ArrayBuffer
 
 final object CirceSupportParser extends SupportParser[Json] {
   implicit final val facade: Facade[Json] = new Facade[Json] {
@@ -22,20 +21,30 @@ final object CirceSupportParser extends SupportParser[Json] {
     }
 
     final def arrayContext(): FContext[Json] = new FContext[Json] {
-      private[this] val vs = ArrayBuffer.empty[Json]
+      private[this] final val vs = List.newBuilder[Json]
       final def add(s: String): Unit = { vs += jstring(s) }
       final def add(v: Json): Unit = { vs += v }
-      final def finish: Json = Json.fromValues(vs)
+      final def finish: Json = Json.fromValues(vs.result())
       final def isObj: Boolean = false
     }
 
     def objectContext(): FContext[Json] = new FContext[Json] {
       private[this] final var key: String = null
-      private[this] final val vs = ArrayBuffer.empty[(String, Json)]
+      private[this] final val m = scala.collection.mutable.Map.empty[String, Json]
+      private[this] final val keys = Vector.newBuilder[String]
+
       final def add(s: String): Unit =
-        if (key == null) { key = s } else { vs += (key -> jstring(s)); key = null }
-      final def add(v: Json): Unit = { vs += (key -> v); key = null }
-      final def finish: Json = Json.fromFields(vs)
+        if (key == null) { key = s } else {
+          if (!m.contains(key)) keys += key
+          m(key) = jstring(s)
+          key = null
+        }
+      final def add(v: Json): Unit = {
+        if (!m.contains(key)) keys += key
+        m(key) = v
+        key = null
+      }
+      final def finish: Json = Json.fromJsonObject(JsonObject.fromMapAndVector(m.toMap, keys.result()))
       final def isObj: Boolean = true
     }
   }


### PR DESCRIPTION
This is a small optimization that turned up during some profiling I was doing yesterday. The idea is that there's no point in building e.g. an `ArrayBuffer` that we're just going to turn into a `List`—we might as well use a `Builder[Json, List[Json]]` from the start.